### PR TITLE
Fix: HTTP response gzip decompression and header normalization

### DIFF
--- a/examples/fastify-openai-unbundled/package-lock.json
+++ b/examples/fastify-openai-unbundled/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../..": {
       "name": "coolhand-node",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coolhand-node",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Monitor and LLM API calls for analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -23,6 +23,7 @@ const isEdgeRuntime = () => {
 // Node.js modules - conditionally imported
 let https: any = null;
 let http: any = null;
+let zlib: any = null;
 
 // Lazy load Node.js modules only when not in Edge runtime
 const loadNodeModules = async () => {
@@ -53,6 +54,14 @@ const loadNodeModules = async () => {
 
     https = httpsModule;
     http = httpModule;
+
+    try {
+      const zlibModule = await import('zlib');
+      zlib = zlibModule;
+    } catch {
+      log('zlib not available — response decompression disabled');
+    }
+
     return true;
   } catch {
     console.warn('⚠️  Node.js HTTP modules not available - falling back to fetch() only');
@@ -381,6 +390,40 @@ function patchFetch(): void {
   }
 }
 
+function decompressBuffer(buffer: Buffer, encoding: string | undefined): Promise<string> {
+  return new Promise((resolve) => {
+    if (!encoding || !zlib) {
+      resolve(buffer.toString('utf-8'));
+      return;
+    }
+
+    const enc = encoding.trim().toLowerCase();
+    let decompressFn: ((buf: Buffer, cb: (err: Error | null, result: Buffer) => void) => void) | null = null;
+
+    if (enc === 'gzip' || enc === 'x-gzip') {
+      decompressFn = zlib.gunzip;
+    } else if (enc === 'deflate') {
+      decompressFn = zlib.inflate;
+    } else if (enc === 'br') {
+      decompressFn = zlib.brotliDecompress;
+    }
+
+    if (!decompressFn) {
+      resolve(buffer.toString('utf-8'));
+      return;
+    }
+
+    decompressFn(buffer, (err: Error | null, result: Buffer) => {
+      if (err) {
+        log(`⚠️ Decompression failed for encoding '${enc}': ${err.message}`);
+        resolve(buffer.toString('utf-8'));
+      } else {
+        resolve(result.toString('utf-8'));
+      }
+    });
+  });
+}
+
 function interceptRequest(
   originalRequest: any,
   options: CoolhandRequestOptions | string | URL,
@@ -418,14 +461,22 @@ function interceptRequest(
   const req = originalRequest(options as any, (res: HttpIncomingMessage) => {
     log(`📥 Response received for call #${callData.id}, status: ${res.statusCode}`);
 
-    let responseBody = '';
+    const responseChunks: Buffer[] = [];
 
     res.on('data', (chunk: any) => {
-      responseBody += chunk.toString();
+      responseChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     });
 
-    res.on('end', () => {
-      callData.response_body = parseBody(responseBody);
+    res.on('end', async () => {
+      try {
+        const rawBuffer = Buffer.concat(responseChunks);
+        const contentEncoding = res.headers?.['content-encoding'];
+        const responseBody = await decompressBuffer(rawBuffer, contentEncoding);
+        callData.response_body = parseBody(responseBody);
+      } catch (err: any) {
+        log(`⚠️ Response body capture failed for call #${callData.id}: ${err?.message}`);
+        callData.response_body = null;
+      }
       callData.response_headers = globalPatternService?.sanitizeHeaders(res.headers, matchedPattern?.pattern) || {};
       callData.status_code = res.statusCode || null;
 

--- a/src/services/PatternMatchingService.ts
+++ b/src/services/PatternMatchingService.ts
@@ -407,6 +407,14 @@ export class PatternMatchingService {
       }
     }
 
+    // Normalize header arrays to strings
+    for (const key of Object.keys(sanitized)) {
+      const val = sanitized[key];
+      if (Array.isArray(val)) {
+        sanitized[key] = val.length === 1 ? val[0] : val.join(', ');
+      }
+    }
+
     return sanitized;
   }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * Run `npm run sync-version` or `npm run build` to regenerate.
  */
 
-export const PACKAGE_VERSION = '0.3.0';
+export const PACKAGE_VERSION = '0.3.1';
 export const PACKAGE_NAME = 'coolhand-node';
 
 /**

--- a/test/pattern-matching-service.test.ts
+++ b/test/pattern-matching-service.test.ts
@@ -642,7 +642,17 @@ describe('PatternMatchingService', () => {
       const sanitized = service.sanitizeHeaders(headers);
 
       expect(sanitized.authorization).toBe('Bearer [REDACTED]');
-      expect(sanitized.accept).toEqual(['application/json', 'text/plain']);
+      expect(sanitized.accept).toBe('application/json, text/plain');
+    });
+
+    it('should unwrap single-element header arrays to string', () => {
+      const headers = {
+        'content-type': ['application/json']
+      };
+
+      const sanitized = service.sanitizeHeaders(headers);
+
+      expect(sanitized['content-type']).toBe('application/json');
     });
 
     it('should handle multiple Bearer token formats', () => {


### PR DESCRIPTION
## What's new
- HTTP response bodies are now correctly decompressed when APIs return gzip, deflate, or brotli encoding. OpenAI, Anthropic, Google AI, and most APIs default to gzip—previously this produced garbled output.
- HTTP header values that are arrays are normalized to strings: single-element arrays unwrap to the string value, multi-element arrays join with commas per RFC 7230.

## What changed
- Response chunk capture now collects raw Buffers instead of string concatenation, enabling proper decompression handling
- `sanitizeHeaders()` normalizes all header arrays after sanitization completes
- Response body capture is now async to handle decompression promises

## Breaking changes
None. These are fixes for data corruption bugs.