### PR TITLE
Bump fast-uri from 3.1.0 to 3.1.2 in /examples/fastify-openai-unbundled

### DIFF
--- a/examples/fastify-openai-unbundled/package-lock.json
+++ b/examples/fastify-openai-unbundled/package-lock.json
@@ -1065,9 +1065,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- Bumps `fast-uri` from 3.1.0 → 3.1.2 in `examples/fastify-openai-unbundled`
- Fixes Dependabot alert #33: path traversal via percent-encoded dot segments (fixed in 3.1.1)
- Fixes Dependabot alert #34: host confusion via percent-encoded authority delimiters (fixed in 3.1.2)

Both are high-severity CVEs. Only the lock file changes — `fast-uri` is a transitive dependency of `@fastify/ajv-compiler`, `ajv`, and `fast-json-stringify`.

## Test plan

- [x] `npm audit` in `examples/fastify-openai-unbundled` reports 0 vulnerabilities
- [x] `fast-uri` version in lock file is `3.1.2`
- [ ] Dependabot closes alerts #33 and #34 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)