### PR TITLE
Feat: Add baseUrl option for self-hosted deployments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coolhand-node",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coolhand-node",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/src/auto-monitor.ts
+++ b/src/auto-monitor.ts
@@ -6,6 +6,7 @@
  *
  * Environment Variables:
  * - COOLHAND_API_KEY (required)
+ * - COOLHAND_BASE_URL (optional: e.g. https://feedback.example.com)
  * - COOLHAND_SILENT (optional: 'true' | 'false', default: 'true')
  * - COOLHAND_PATTERNS_FILE (optional: path to custom patterns file)
  * - COOLHAND_DEBUG (optional: 'true' | 'false', default: 'false')
@@ -29,6 +30,7 @@ if (apiKey) {
   const silent = process.env.COOLHAND_SILENT !== 'false'; // Default to true unless explicitly false
   const patternsFile = process.env.COOLHAND_PATTERNS_FILE;
   const debug = process.env.COOLHAND_DEBUG === 'true'; // Default to false unless explicitly true
+  const baseUrl = process.env.COOLHAND_BASE_URL;
 
   // Async initialization wrapped in IIFE
   (async () => {
@@ -41,7 +43,8 @@ if (apiKey) {
         apiKey,
         silent,
         patternsFile,
-        debug
+        debug,
+        baseUrl
       });
 
       if (!silent) {

--- a/src/coolhand.ts
+++ b/src/coolhand.ts
@@ -27,7 +27,8 @@ export class Coolhand {
     const serviceConfig = {
       apiKey,
       silent: this.silent,
-      debug: options.debug
+      debug: options.debug,
+      baseUrl: options.baseUrl
     };
 
     this.loggingService = new LoggingService(serviceConfig);

--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -89,6 +89,7 @@ interface GlobalMonitorConfig {
   silent?: boolean;
   patternsFile?: string;
   debug?: boolean;
+  baseUrl?: string;
 }
 
 /**
@@ -108,7 +109,8 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
   globalLoggingService = new LoggingService({
     apiKey: config.apiKey,
     silent,
-    debug: config.debug
+    debug: config.debug,
+    baseUrl: config.baseUrl
   });
 
   // Load Node.js modules if available

--- a/src/services/BaseService.ts
+++ b/src/services/BaseService.ts
@@ -15,7 +15,7 @@ export abstract class BaseService {
   protected apiEndpoint: string;
 
   static resolveBaseUrl(baseUrl?: string): string {
-    if (!baseUrl) return 'https://coolhandlabs.com';
+    if (!baseUrl) { return 'https://coolhandlabs.com'; }
     const normalized = baseUrl.replace(/\/$/, '');
 
     let parsed: URL;
@@ -27,7 +27,7 @@ export abstract class BaseService {
       );
     }
 
-    if (parsed.protocol === 'https:') return normalized;
+    if (parsed.protocol === 'https:') { return normalized; }
     if (parsed.protocol === 'http:' && (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1')) {
       return normalized;
     }

--- a/src/services/BaseService.ts
+++ b/src/services/BaseService.ts
@@ -14,6 +14,28 @@ export abstract class BaseService {
   protected debug: boolean;
   protected apiEndpoint: string;
 
+  static resolveBaseUrl(baseUrl?: string): string {
+    if (!baseUrl) return 'https://coolhandlabs.com';
+    const normalized = baseUrl.replace(/\/$/, '');
+
+    let parsed: URL;
+    try {
+      parsed = new URL(normalized);
+    } catch {
+      throw new Error(
+        `baseUrl must use https:// (or http://localhost for local dev). Got: ${baseUrl}`
+      );
+    }
+
+    if (parsed.protocol === 'https:') return normalized;
+    if (parsed.protocol === 'http:' && (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1')) {
+      return normalized;
+    }
+    throw new Error(
+      `baseUrl must use https:// (or http://localhost for local dev). Got: ${baseUrl}`
+    );
+  }
+
   constructor(config: BaseServiceConfig, endpoint: string) {
     this.apiKey = config.apiKey;
     this.silent = config.silent;

--- a/src/services/BaseService.ts
+++ b/src/services/BaseService.ts
@@ -16,7 +16,7 @@ export abstract class BaseService {
 
   static resolveBaseUrl(baseUrl?: string): string {
     if (!baseUrl) { return 'https://coolhandlabs.com'; }
-    const normalized = baseUrl.replace(/\/$/, '');
+    const normalized = baseUrl.replace(/\/+$/, '');
 
     let parsed: URL;
     try {

--- a/src/services/FeedbackService.ts
+++ b/src/services/FeedbackService.ts
@@ -2,11 +2,13 @@ import { LLMRequestLogFeedback, LLMRequestLogFeedbackPayload, LLMRequestLogFeedb
 import { CollectionMethod } from '../utils/collector.js';
 import { BaseService, BaseServiceConfig } from './BaseService.js';
 
-export interface FeedbackServiceConfig extends BaseServiceConfig {}
+export interface FeedbackServiceConfig extends BaseServiceConfig {
+  baseUrl?: string;
+}
 
 export class FeedbackService extends BaseService {
   constructor(config: FeedbackServiceConfig) {
-    super(config, 'https://coolhandlabs.com/api/v2/llm_request_log_feedbacks');
+    super(config, BaseService.resolveBaseUrl(config.baseUrl) + '/api/v2/llm_request_log_feedbacks');
   }
 
   public async createFeedback(feedback: LLMRequestLogFeedback, collectionMethod?: CollectionMethod): Promise<LLMRequestLogFeedbackResponse | null> {

--- a/src/services/LoggingService.ts
+++ b/src/services/LoggingService.ts
@@ -2,11 +2,13 @@ import { CoolhandCallData, CoolhandLogPayload, CoolhandMatchedPattern } from '..
 import { CollectionMethod } from '../utils/collector.js';
 import { BaseService, BaseServiceConfig } from './BaseService.js';
 
-export interface LoggingServiceConfig extends BaseServiceConfig {}
+export interface LoggingServiceConfig extends BaseServiceConfig {
+  baseUrl?: string;
+}
 
 export class LoggingService extends BaseService {
   constructor(config: LoggingServiceConfig) {
-    super(config, 'https://coolhandlabs.com/api/v2/llm_request_logs');
+    super(config, BaseService.resolveBaseUrl(config.baseUrl) + '/api/v2/llm_request_logs');
   }
 
   public async logRequestToAPI(callData: CoolhandCallData, matchedPattern?: CoolhandMatchedPattern, collectionMethod?: CollectionMethod): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface CoolhandOptions {
   silent?: boolean;
   patternsFile?: string;
   debug?: boolean;
+  baseUrl?: string;
 }
 
 export interface CoolhandCallData {

--- a/test/coolhand.test.ts
+++ b/test/coolhand.test.ts
@@ -61,6 +61,65 @@ describe('Coolhand Node Monitor', () => {
       })).not.toThrow();
     });
 
+    it('should allow http://127.0.0.1 for local dev', () => {
+      const monitor = new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'http://127.0.0.1:3000'
+      });
+      expect(monitor.getStats().apiEndpoint).toBe(
+        'http://127.0.0.1:3000/api/v2/llm_request_logs'
+      );
+    });
+
+    it('should strip multiple trailing slashes from baseUrl', () => {
+      const monitor = new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'https://feedback.example.com//'
+      });
+      expect(monitor.getStats().apiEndpoint).toBe(
+        'https://feedback.example.com/api/v2/llm_request_logs'
+      );
+    });
+
+    it('should use default endpoint when baseUrl is undefined', () => {
+      const monitor = new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: undefined
+      });
+      expect(monitor.getStats().apiEndpoint).toBe(
+        'https://coolhandlabs.com/api/v2/llm_request_logs'
+      );
+    });
+
+    it('should POST feedback to the custom baseUrl (HTTP-layer)', async () => {
+      const originalFetch = (global as any).fetch;
+      let capturedUrl: string | undefined;
+      (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
+        capturedUrl = url;
+        return {
+          ok: true,
+          status: 200,
+          json: jest.fn().mockResolvedValue({ id: 1, like: true, created_at: '', updated_at: '' }),
+          text: jest.fn().mockResolvedValue('')
+        };
+      });
+
+      const monitor = new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'https://self-hosted.example.com'
+      });
+
+      await monitor.createFeedback({ like: true });
+      expect(capturedUrl).toBe(
+        'https://self-hosted.example.com/api/v2/llm_request_log_feedbacks'
+      );
+      (global as any).fetch = originalFetch;
+    });
+
     it('should reject non-https non-localhost baseUrl', () => {
       expect(() => new Coolhand({
         apiKey: 'test-key',

--- a/test/coolhand.test.ts
+++ b/test/coolhand.test.ts
@@ -30,6 +30,58 @@ describe('Coolhand Node Monitor', () => {
       const stats = monitor.getStats();
       expect(stats.apiEndpoint).toBe('https://coolhandlabs.com/api/v2/llm_request_logs');
     });
+
+    it('should use custom baseUrl when provided', () => {
+      const monitor = new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'https://feedback.example.com'
+      });
+      expect(monitor.getStats().apiEndpoint).toBe(
+        'https://feedback.example.com/api/v2/llm_request_logs'
+      );
+    });
+
+    it('should normalize trailing slash in baseUrl', () => {
+      const monitor = new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'https://feedback.example.com/'
+      });
+      expect(monitor.getStats().apiEndpoint).toBe(
+        'https://feedback.example.com/api/v2/llm_request_logs'
+      );
+    });
+
+    it('should allow http://localhost for local dev', () => {
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'http://localhost:3000'
+      })).not.toThrow();
+    });
+
+    it('should reject non-https non-localhost baseUrl', () => {
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'http://example.com'
+      })).toThrow('baseUrl must use https://');
+    });
+
+    it('should reject hosts that only prefix-match localhost', () => {
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'http://localhost.evil.com'
+      })).toThrow('baseUrl must use https://');
+
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'http://127.0.0.1.attacker.com'
+      })).toThrow('baseUrl must use https://');
+    });
   });
 
   describe('Header sanitization', () => {

--- a/test/feedback-service.test.ts
+++ b/test/feedback-service.test.ts
@@ -30,6 +30,72 @@ describe('FeedbackService', () => {
 
       expect(service.getApiEndpoint()).toBe('https://coolhandlabs.com/api/v2/llm_request_log_feedbacks');
     });
+
+    it('should use custom baseUrl for feedback endpoint', () => {
+      const service = new FeedbackService({
+        apiKey: 'test-api-key',
+        silent: true,
+        baseUrl: 'https://self-hosted.example.com'
+      });
+      expect(service.getApiEndpoint()).toBe(
+        'https://self-hosted.example.com/api/v2/llm_request_log_feedbacks'
+      );
+    });
+
+    it('should strip multiple trailing slashes from baseUrl', () => {
+      const service = new FeedbackService({
+        apiKey: 'test-api-key',
+        silent: true,
+        baseUrl: 'https://self-hosted.example.com//'
+      });
+      expect(service.getApiEndpoint()).toBe(
+        'https://self-hosted.example.com/api/v2/llm_request_log_feedbacks'
+      );
+    });
+
+    it('should allow http://127.0.0.1 for local dev', () => {
+      const service = new FeedbackService({
+        apiKey: 'test-api-key',
+        silent: true,
+        baseUrl: 'http://127.0.0.1:3000'
+      });
+      expect(service.getApiEndpoint()).toBe(
+        'http://127.0.0.1:3000/api/v2/llm_request_log_feedbacks'
+      );
+    });
+
+    it('should use default endpoint when baseUrl is undefined', () => {
+      const service = new FeedbackService({
+        apiKey: 'test-api-key',
+        silent: true,
+        baseUrl: undefined
+      });
+      expect(service.getApiEndpoint()).toBe('https://coolhandlabs.com/api/v2/llm_request_log_feedbacks');
+    });
+
+    it('should POST feedback to the custom baseUrl', async () => {
+      let capturedUrl: string | undefined;
+      (global as any).fetch = jest.fn().mockImplementation(async (url: string) => {
+        capturedUrl = url;
+        return {
+          ok: true,
+          status: 200,
+          json: jest.fn().mockResolvedValue({ id: 1, like: true, created_at: '', updated_at: '' }),
+          text: jest.fn().mockResolvedValue('')
+        };
+      });
+
+      const service = new FeedbackService({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'https://self-hosted.example.com'
+      });
+
+      await service.createFeedback({ like: true });
+      expect(capturedUrl).toBe(
+        'https://self-hosted.example.com/api/v2/llm_request_log_feedbacks'
+      );
+    });
   });
 
   describe('Feedback creation', () => {

--- a/test/global-monitor.test.ts
+++ b/test/global-monitor.test.ts
@@ -372,5 +372,16 @@ describe('Global Monitor', () => {
       // Verify the configuration was accepted
       expect(config.patternsFile).toBe('./custom-patterns.json');
     });
+
+    it('should accept baseUrl configuration', async () => {
+      const config = {
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'https://self-hosted.example.com'
+      };
+
+      // Should accept baseUrl without throwing
+      await expect(globalMonitor.initializeGlobalMonitoring(config)).resolves.not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
## What's new

- `baseUrl` option on `new Coolhand({ baseUrl })` and `initializeGlobalMonitoring({ baseUrl })` to redirect all log and feedback POSTs to a custom host.
- `COOLHAND_BASE_URL` environment variable for the auto-monitor path.
- Trailing slashes in `baseUrl` are normalized automatically.

## What changed

- `CoolhandOptions`, `GlobalMonitorConfig`, `LoggingServiceConfig`, and `FeedbackServiceConfig` all accept an optional `baseUrl` string. When omitted, behavior is unchanged (defaults to `https://coolhandlabs.com`).
- `BaseService.resolveBaseUrl()` centralizes URL validation: `https://` URLs are accepted; `http://localhost` and `http://127.0.0.1` are allowed for local dev; all other non-HTTPS URLs throw.

## Breaking changes

None. The default host is unchanged; existing code requires no modifications.

Closes #33