### PR TITLE
feat: add baseUrl option for self-hosted deployments

### DIFF
--- a/src/auto-monitor.ts
+++ b/src/auto-monitor.ts
@@ -9,6 +9,7 @@
  * - COOLHAND_SILENT (optional: 'true' | 'false', default: 'true')
  * - COOLHAND_PATTERNS_FILE (optional: path to custom patterns file)
  * - COOLHAND_DEBUG (optional: 'true' | 'false', default: 'false')
+ * - COOLHAND_BASE_URL (optional: base URL for self-hosted deployments, default: https://coolhandlabs.com)
  *
  * Usage:
  * Just import this module at the very top of your main file:
@@ -29,6 +30,7 @@ if (apiKey) {
   const silent = process.env.COOLHAND_SILENT !== 'false'; // Default to true unless explicitly false
   const patternsFile = process.env.COOLHAND_PATTERNS_FILE;
   const debug = process.env.COOLHAND_DEBUG === 'true'; // Default to false unless explicitly true
+  const baseUrl = process.env.COOLHAND_BASE_URL;
 
   // Async initialization wrapped in IIFE
   (async () => {
@@ -41,7 +43,8 @@ if (apiKey) {
         apiKey,
         silent,
         patternsFile,
-        debug
+        debug,
+        baseUrl
       });
 
       if (!silent) {

--- a/src/coolhand.ts
+++ b/src/coolhand.ts
@@ -27,7 +27,8 @@ export class Coolhand {
     const serviceConfig = {
       apiKey,
       silent: this.silent,
-      debug: options.debug
+      debug: options.debug,
+      baseUrl: options.baseUrl
     };
 
     this.loggingService = new LoggingService(serviceConfig);

--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -89,6 +89,7 @@ interface GlobalMonitorConfig {
   silent?: boolean;
   patternsFile?: string;
   debug?: boolean;
+  baseUrl?: string;
 }
 
 /**
@@ -108,7 +109,8 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
   globalLoggingService = new LoggingService({
     apiKey: config.apiKey,
     silent,
-    debug: config.debug
+    debug: config.debug,
+    baseUrl: config.baseUrl
   });
 
   // Load Node.js modules if available

--- a/src/services/BaseService.ts
+++ b/src/services/BaseService.ts
@@ -6,6 +6,7 @@ export interface BaseServiceConfig {
   apiKey: string;
   silent: boolean;
   debug?: boolean;
+  baseUrl?: string;
 }
 
 export abstract class BaseService {
@@ -13,6 +14,25 @@ export abstract class BaseService {
   protected silent: boolean;
   protected debug: boolean;
   protected apiEndpoint: string;
+
+  static buildEndpoint(baseUrl: string | undefined, path: string): string {
+    const base = (baseUrl ?? 'https://coolhandlabs.com').replace(/\/+$/, '');
+    let parsed: URL;
+    try {
+      parsed = new URL(base);
+    } catch {
+      throw new Error(`baseUrl is not a valid URL. Got: ${base}`);
+    }
+    const isHttps = parsed.protocol === 'https:';
+    const isLocalHttp = parsed.protocol === 'http:' &&
+      (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1');
+    if (!isHttps && !isLocalHttp) {
+      throw new Error(
+        `baseUrl must use https:// (use http://localhost or http://127.0.0.1 for local dev). Got: ${base}`
+      );
+    }
+    return base + path;
+  }
 
   constructor(config: BaseServiceConfig, endpoint: string) {
     this.apiKey = config.apiKey;

--- a/src/services/FeedbackService.ts
+++ b/src/services/FeedbackService.ts
@@ -6,7 +6,7 @@ export interface FeedbackServiceConfig extends BaseServiceConfig {}
 
 export class FeedbackService extends BaseService {
   constructor(config: FeedbackServiceConfig) {
-    super(config, 'https://coolhandlabs.com/api/v2/llm_request_log_feedbacks');
+    super(config, BaseService.buildEndpoint(config.baseUrl, '/api/v2/llm_request_log_feedbacks'));
   }
 
   public async createFeedback(feedback: LLMRequestLogFeedback, collectionMethod?: CollectionMethod): Promise<LLMRequestLogFeedbackResponse | null> {

--- a/src/services/LoggingService.ts
+++ b/src/services/LoggingService.ts
@@ -6,7 +6,7 @@ export interface LoggingServiceConfig extends BaseServiceConfig {}
 
 export class LoggingService extends BaseService {
   constructor(config: LoggingServiceConfig) {
-    super(config, 'https://coolhandlabs.com/api/v2/llm_request_logs');
+    super(config, BaseService.buildEndpoint(config.baseUrl, '/api/v2/llm_request_logs'));
   }
 
   public async logRequestToAPI(callData: CoolhandCallData, matchedPattern?: CoolhandMatchedPattern, collectionMethod?: CollectionMethod): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface CoolhandOptions {
   silent?: boolean;
   patternsFile?: string;
   debug?: boolean;
+  baseUrl?: string;
 }
 
 export interface CoolhandCallData {

--- a/test/integration-config.test.ts
+++ b/test/integration-config.test.ts
@@ -623,3 +623,133 @@ describe('FeedbackService debug mode integration', () => {
     expect(body.llm_request_log_feedback.like).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 11. baseUrl configuration
+// ---------------------------------------------------------------------------
+
+describe('baseUrl configuration', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('should use default coolhandlabs.com endpoint when baseUrl is omitted', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      const instance = new Coolhand({ apiKey: 'test-key', silent: true });
+      expect(instance.getStats().apiEndpoint).toBe('https://coolhandlabs.com/api/v2/llm_request_logs');
+    });
+  });
+
+  it('should use custom https baseUrl for LoggingService endpoint', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      const instance = new Coolhand({ apiKey: 'test-key', silent: true, baseUrl: 'https://feedback.example.com' });
+      expect(instance.getStats().apiEndpoint).toBe('https://feedback.example.com/api/v2/llm_request_logs');
+    });
+  });
+
+  it('should normalize trailing slash in baseUrl', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      const instance = new Coolhand({ apiKey: 'test-key', silent: true, baseUrl: 'https://feedback.example.com/' });
+      expect(instance.getStats().apiEndpoint).toBe('https://feedback.example.com/api/v2/llm_request_logs');
+    });
+  });
+
+  it('should allow http://localhost baseUrl', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      expect(() => new Coolhand({ apiKey: 'test-key', silent: true, baseUrl: 'http://localhost:3000' })).not.toThrow();
+      const instance = new Coolhand({ apiKey: 'test-key', silent: true, baseUrl: 'http://localhost:3000' });
+      expect(instance.getStats().apiEndpoint).toBe('http://localhost:3000/api/v2/llm_request_logs');
+    });
+  });
+
+  it('should allow http://127.0.0.1 baseUrl', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      expect(() => new Coolhand({ apiKey: 'test-key', silent: true, baseUrl: 'http://127.0.0.1:4000' })).not.toThrow();
+    });
+  });
+
+  it('should reject http:// non-localhost baseUrl', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      expect(() => new Coolhand({ apiKey: 'test-key', silent: true, baseUrl: 'http://feedback.example.com' }))
+        .toThrow(/baseUrl must use https:\/\//);
+    });
+  });
+
+  it('should reject http://localhost.attacker.com (hostname prefix bypass)', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      expect(() => new Coolhand({ apiKey: 'test-key', silent: true, baseUrl: 'http://localhost.attacker.com' }))
+        .toThrow(/baseUrl must use https:\/\//);
+    });
+  });
+
+  it('should reject http://127.0.0.1.evil.com (hostname prefix bypass)', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      expect(() => new Coolhand({ apiKey: 'test-key', silent: true, baseUrl: 'http://127.0.0.1.evil.com' }))
+        .toThrow(/baseUrl must use https:\/\//);
+    });
+  });
+
+  it('should reject an invalid URL', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      expect(() => new Coolhand({ apiKey: 'test-key', silent: true, baseUrl: 'not-a-url' }))
+        .toThrow(/not a valid URL/);
+    });
+  });
+
+  it('should use custom baseUrl in global monitoring', async () => {
+    let stats: any;
+    await jest.isolateModulesAsync(async () => {
+      jest.spyOn(console, 'log').mockImplementation();
+      jest.spyOn(console, 'warn').mockImplementation();
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        clone: () => ({ text: () => Promise.resolve('{}') }),
+      });
+
+      const mod = require('../src/global-monitor');
+      await mod.initializeGlobalMonitoring({ apiKey: 'k', silent: true, baseUrl: 'https://self-hosted.example.com' });
+      stats = mod.getGlobalStats();
+    });
+
+    expect(stats.apiEndpoint).toContain('self-hosted.example.com');
+    expect(stats.apiEndpoint).toContain('/api/v2/llm_request_logs');
+  });
+
+  it('should read COOLHAND_BASE_URL from environment in auto-monitor', async () => {
+    const envBackup = process.env.COOLHAND_BASE_URL;
+    const apiKeyBackup = process.env.COOLHAND_API_KEY;
+
+    process.env.COOLHAND_API_KEY = 'auto-baseurl-test-key';
+    process.env.COOLHAND_BASE_URL = 'https://self-hosted.example.com';
+
+    jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(console, 'warn').mockImplementation();
+    jest.spyOn(console, 'error').mockImplementation();
+
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      clone: () => ({ text: () => Promise.resolve('{}') }),
+    });
+
+    try {
+      const mod = await import('../src/auto-monitor');
+      await new Promise(r => setTimeout(r, 50));
+      expect(mod.getGlobalStats().apiEndpoint).toContain('self-hosted.example.com');
+    } finally {
+      if (envBackup === undefined) { delete process.env.COOLHAND_BASE_URL; } else { process.env.COOLHAND_BASE_URL = envBackup; }
+      if (apiKeyBackup === undefined) { delete process.env.COOLHAND_API_KEY; } else { process.env.COOLHAND_API_KEY = apiKeyBackup; }
+    }
+  });
+});


### PR DESCRIPTION
## What's new

- `baseUrl` option added to `new Coolhand({ baseUrl })` and `initializeGlobalMonitoring({ baseUrl })` — redirects all log and feedback POSTs to a custom host.
- `COOLHAND_BASE_URL` environment variable supported in the auto-monitor module.
- Trailing slashes in `baseUrl` are normalized before the `/api/v2` path is appended.

## Changed

- `LoggingService` and `FeedbackService` no longer hardcode `https://coolhandlabs.com` — the base is resolved via `BaseService.buildEndpoint()`, which defaults to the same URL when `baseUrl` is unset (no behavior change for existing callers).
- `BaseServiceConfig`, `CoolhandOptions`, and the internal `GlobalMonitorConfig` interface each gain an optional `baseUrl` field.

## Breaking changes / validation

None for existing callers. New callers providing `baseUrl` must use `https://` or exactly `http://localhost` / `http://127.0.0.1` (for local dev). Any other `http://` URL — including lookalike hostnames such as `http://localhost.attacker.com` — is rejected at construction time with a descriptive error. Malformed URLs also throw immediately.

Closes #33.