### PR TITLE
feat: add baseUrl config option for self-hosted deployments (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-11
+
+### ✨ New Features
+- **`baseUrl` option** — Both `new Coolhand({ baseUrl })` and `initializeGlobalMonitoring({ baseUrl })` now accept an optional `baseUrl` to redirect log and feedback POSTs to a self-hosted endpoint. When omitted, behavior is unchanged (default: `https://coolhandlabs.com`).
+- **`COOLHAND_BASE_URL` environment variable** — Auto-monitor reads this variable and forwards it to `initializeGlobalMonitoring`, enabling zero-code-change self-hosted setups.
+
+### 🔒 Validation
+- `baseUrl` must use `https://` or `http://localhost` / `http://127.0.0.1` / `http://*.localhost` (for local dev). Any other scheme or non-loopback `http://` host throws immediately with a clear error message.
+- Trailing slashes on `baseUrl` are normalized automatically before the v2 path is appended.
+
 ## [0.2.0] - 2026-03-01
 
 ### 🐛 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ const feedback = await coolhand.createFeedback({
 | `silent` | boolean | `true` | Whether to suppress console output |
 | `debug` | boolean | `false` | Enable debug mode (API calls will be mocked) |
 | `patternsFile` | string | `undefined` | Path to custom API patterns file |
+| `baseUrl` | string | `'https://coolhandlabs.com'` | Override the API host for self-hosted deployments. Must be `https://` (or `http://localhost` for local dev). |
 
 ### Environment Variables
 
@@ -227,10 +228,11 @@ const feedback = await coolhand.createFeedback({
 | `COOLHAND_SILENT` | `'true'` \| `'false'` | `'true'` | Whether to suppress console output |
 | `COOLHAND_DEBUG` | `'true'` \| `'false'` | `'false'` | Enable debug mode |
 | `COOLHAND_PATTERNS_FILE` | string | `undefined` | Path to custom API patterns file |
+| `COOLHAND_BASE_URL` | string | `undefined` | Override the API host (e.g. `https://feedback.example.com`). Same rules as `baseUrl` option. |
 
 ### Instance-Based Monitoring Options
 
-Same options as global monitoring, passed to the `Coolhand` constructor.
+Same options as global monitoring, passed to the `Coolhand` constructor. Includes `baseUrl`.
 
 ## TypeScript Support
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coolhand-node",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Monitor and LLM API calls for analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/src/auto-monitor.ts
+++ b/src/auto-monitor.ts
@@ -9,6 +9,7 @@
  * - COOLHAND_SILENT (optional: 'true' | 'false', default: 'true')
  * - COOLHAND_PATTERNS_FILE (optional: path to custom patterns file)
  * - COOLHAND_DEBUG (optional: 'true' | 'false', default: 'false')
+ * - COOLHAND_BASE_URL (optional: self-hosted endpoint, e.g. 'https://feedback.example.com')
  *
  * Usage:
  * Just import this module at the very top of your main file:
@@ -29,6 +30,7 @@ if (apiKey) {
   const silent = process.env.COOLHAND_SILENT !== 'false'; // Default to true unless explicitly false
   const patternsFile = process.env.COOLHAND_PATTERNS_FILE;
   const debug = process.env.COOLHAND_DEBUG === 'true'; // Default to false unless explicitly true
+  const baseUrl = process.env.COOLHAND_BASE_URL;
 
   // Async initialization wrapped in IIFE
   (async () => {
@@ -41,7 +43,8 @@ if (apiKey) {
         apiKey,
         silent,
         patternsFile,
-        debug
+        debug,
+        baseUrl
       });
 
       if (!silent) {

--- a/src/coolhand.ts
+++ b/src/coolhand.ts
@@ -27,7 +27,8 @@ export class Coolhand {
     const serviceConfig = {
       apiKey,
       silent: this.silent,
-      debug: options.debug
+      debug: options.debug,
+      baseUrl: options.baseUrl
     };
 
     this.loggingService = new LoggingService(serviceConfig);

--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -89,6 +89,7 @@ interface GlobalMonitorConfig {
   silent?: boolean;
   patternsFile?: string;
   debug?: boolean;
+  baseUrl?: string;
 }
 
 /**
@@ -108,7 +109,8 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
   globalLoggingService = new LoggingService({
     apiKey: config.apiKey,
     silent,
-    debug: config.debug
+    debug: config.debug,
+    baseUrl: config.baseUrl
   });
 
   // Load Node.js modules if available

--- a/src/services/BaseService.ts
+++ b/src/services/BaseService.ts
@@ -16,10 +16,13 @@ function validateBaseUrl(raw: string): void {
   } catch {
     throw new Error(`Invalid baseUrl: "${raw}" is not a valid URL`);
   }
+  if (!url.hostname) {
+    throw new Error(`baseUrl must include a hostname. Got: "${raw}"`);
+  }
   if (url.protocol === 'https:') { return; }
   if (url.protocol === 'http:') {
     const h = url.hostname;
-    if (h === 'localhost' || h === '127.0.0.1' || h === '[::1]' || h.endsWith('.localhost')) { return; }
+    if (h === 'localhost' || h === '127.0.0.1' || h === '[::1]') { return; }
   }
   throw new Error(
     `baseUrl must use https:// (got: "${raw}"). For local dev, http://localhost is allowed.`

--- a/src/services/BaseService.ts
+++ b/src/services/BaseService.ts
@@ -6,6 +6,28 @@ export interface BaseServiceConfig {
   apiKey: string;
   silent: boolean;
   debug?: boolean;
+  baseUrl?: string;
+}
+
+function validateBaseUrl(raw: string): void {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`Invalid baseUrl: "${raw}" is not a valid URL`);
+  }
+  if (url.protocol === 'https:') { return; }
+  if (url.protocol === 'http:') {
+    const h = url.hostname;
+    if (h === 'localhost' || h === '127.0.0.1' || h === '[::1]' || h.endsWith('.localhost')) { return; }
+  }
+  throw new Error(
+    `baseUrl must use https:// (got: "${raw}"). For local dev, http://localhost is allowed.`
+  );
+}
+
+function normalizeBaseUrl(raw: string): string {
+  return raw.replace(/\/+$/, '');
 }
 
 export abstract class BaseService {
@@ -14,11 +36,13 @@ export abstract class BaseService {
   protected debug: boolean;
   protected apiEndpoint: string;
 
-  constructor(config: BaseServiceConfig, endpoint: string) {
+  constructor(config: BaseServiceConfig, endpointPath: string) {
     this.apiKey = config.apiKey;
     this.silent = config.silent;
     this.debug = config.debug || false;
-    this.apiEndpoint = endpoint;
+    const rawBase = config.baseUrl ?? 'https://coolhandlabs.com';
+    validateBaseUrl(rawBase);
+    this.apiEndpoint = normalizeBaseUrl(rawBase) + endpointPath;
   }
 
   protected createRequestOptions(payload: any): RequestInit {

--- a/src/services/FeedbackService.ts
+++ b/src/services/FeedbackService.ts
@@ -6,7 +6,7 @@ export interface FeedbackServiceConfig extends BaseServiceConfig {}
 
 export class FeedbackService extends BaseService {
   constructor(config: FeedbackServiceConfig) {
-    super(config, 'https://coolhandlabs.com/api/v2/llm_request_log_feedbacks');
+    super(config, '/api/v2/llm_request_log_feedbacks');
   }
 
   public async createFeedback(feedback: LLMRequestLogFeedback, collectionMethod?: CollectionMethod): Promise<LLMRequestLogFeedbackResponse | null> {

--- a/src/services/LoggingService.ts
+++ b/src/services/LoggingService.ts
@@ -6,7 +6,7 @@ export interface LoggingServiceConfig extends BaseServiceConfig {}
 
 export class LoggingService extends BaseService {
   constructor(config: LoggingServiceConfig) {
-    super(config, 'https://coolhandlabs.com/api/v2/llm_request_logs');
+    super(config, '/api/v2/llm_request_logs');
   }
 
   public async logRequestToAPI(callData: CoolhandCallData, matchedPattern?: CoolhandMatchedPattern, collectionMethod?: CollectionMethod): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface CoolhandOptions {
   silent?: boolean;
   patternsFile?: string;
   debug?: boolean;
+  baseUrl?: string;
 }
 
 export interface CoolhandCallData {

--- a/test/base-url.test.ts
+++ b/test/base-url.test.ts
@@ -1,6 +1,20 @@
 import { Coolhand } from '../src/index';
 import { LoggingService } from '../src/services/LoggingService';
 import { FeedbackService } from '../src/services/FeedbackService';
+import { CoolhandCallData } from '../src/types';
+
+const fakeCallData: CoolhandCallData = {
+  id: 1,
+  timestamp: new Date().toISOString(),
+  method: 'POST',
+  url: 'https://api.openai.com/v1/chat/completions',
+  headers: {},
+  request_body: null,
+  response_body: null,
+  response_headers: null,
+  status_code: 200,
+  protocol: 'https'
+};
 
 describe('baseUrl configuration', () => {
   describe('Coolhand constructor', () => {
@@ -83,6 +97,31 @@ describe('baseUrl configuration', () => {
         baseUrl: 'not-a-url'
       })).toThrow('Invalid baseUrl');
     });
+
+    it('rejects ftp:// (valid URL, wrong scheme)', () => {
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'ftp://files.example.com'
+      })).toThrow('baseUrl must use https://');
+    });
+
+    // Pin these so a future refactor to startsWith/includes can't accidentally allow them
+    it('rejects http://localhost.attacker.com (prefix-bypass attempt)', () => {
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'http://localhost.attacker.com'
+      })).toThrow('baseUrl must use https://');
+    });
+
+    it('rejects http://127.0.0.1.evil.com (prefix-bypass attempt)', () => {
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'http://127.0.0.1.evil.com'
+      })).toThrow('baseUrl must use https://');
+    });
   });
 
   describe('LoggingService', () => {
@@ -94,6 +133,29 @@ describe('baseUrl configuration', () => {
       });
       expect(svc.getApiEndpoint()).toBe('https://self-hosted.internal/api/v2/llm_request_logs');
     });
+
+    it('POSTs to the custom baseUrl at the HTTP layer', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: 42 })
+      });
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mockFetch as any;
+      try {
+        const svc = new LoggingService({
+          apiKey: 'k',
+          silent: true,
+          baseUrl: 'https://self-hosted.example.com'
+        });
+        await svc.logRequestToAPI(fakeCallData);
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://self-hosted.example.com/api/v2/llm_request_logs',
+          expect.objectContaining({ method: 'POST' })
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
   });
 
   describe('FeedbackService', () => {
@@ -104,6 +166,29 @@ describe('baseUrl configuration', () => {
         baseUrl: 'https://self-hosted.internal'
       });
       expect(svc.getApiEndpoint()).toBe('https://self-hosted.internal/api/v2/llm_request_log_feedbacks');
+    });
+
+    it('POSTs to the custom baseUrl at the HTTP layer', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: 1, like: true })
+      });
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mockFetch as any;
+      try {
+        const svc = new FeedbackService({
+          apiKey: 'k',
+          silent: true,
+          baseUrl: 'https://self-hosted.example.com'
+        });
+        await svc.createFeedback({ like: true });
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://self-hosted.example.com/api/v2/llm_request_log_feedbacks',
+          expect.objectContaining({ method: 'POST' })
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
     });
   });
 

--- a/test/base-url.test.ts
+++ b/test/base-url.test.ts
@@ -1,0 +1,162 @@
+import { Coolhand } from '../src/index';
+import { LoggingService } from '../src/services/LoggingService';
+import { FeedbackService } from '../src/services/FeedbackService';
+
+describe('baseUrl configuration', () => {
+  describe('Coolhand constructor', () => {
+    it('uses the default endpoint when baseUrl is omitted', () => {
+      const client = new Coolhand({ apiKey: 'test-key', silent: true });
+      expect(client.getStats().apiEndpoint).toBe('https://coolhandlabs.com/api/v2/llm_request_logs');
+    });
+
+    it('uses a custom https baseUrl', () => {
+      const client = new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'https://feedback.example.com'
+      });
+      expect(client.getStats().apiEndpoint).toBe('https://feedback.example.com/api/v2/llm_request_logs');
+    });
+
+    it('normalizes trailing slashes on baseUrl', () => {
+      const client = new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'https://feedback.example.com/'
+      });
+      expect(client.getStats().apiEndpoint).toBe('https://feedback.example.com/api/v2/llm_request_logs');
+    });
+
+    it('normalizes multiple trailing slashes', () => {
+      const client = new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'https://feedback.example.com///'
+      });
+      expect(client.getStats().apiEndpoint).toBe('https://feedback.example.com/api/v2/llm_request_logs');
+    });
+
+    it('accepts http://localhost for local dev', () => {
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'http://localhost:3000'
+      })).not.toThrow();
+    });
+
+    it('accepts http://127.0.0.1 for local dev', () => {
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'http://127.0.0.1:8080'
+      })).not.toThrow();
+    });
+
+    it('accepts http://[::1] (IPv6 loopback) for local dev', () => {
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'http://[::1]:3000'
+      })).not.toThrow();
+    });
+
+    it('rejects http://0.0.0.0 (unspecified address)', () => {
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'http://0.0.0.0:3000'
+      })).toThrow('baseUrl must use https://');
+    });
+
+    it('rejects http:// on a non-localhost host', () => {
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'http://feedback.example.com'
+      })).toThrow('baseUrl must use https://');
+    });
+
+    it('rejects a non-URL string', () => {
+      expect(() => new Coolhand({
+        apiKey: 'test-key',
+        silent: true,
+        baseUrl: 'not-a-url'
+      })).toThrow('Invalid baseUrl');
+    });
+  });
+
+  describe('LoggingService', () => {
+    it('builds the correct endpoint from a custom baseUrl', () => {
+      const svc = new LoggingService({
+        apiKey: 'k',
+        silent: true,
+        baseUrl: 'https://self-hosted.internal'
+      });
+      expect(svc.getApiEndpoint()).toBe('https://self-hosted.internal/api/v2/llm_request_logs');
+    });
+  });
+
+  describe('FeedbackService', () => {
+    it('builds the correct endpoint from a custom baseUrl', () => {
+      const svc = new FeedbackService({
+        apiKey: 'k',
+        silent: true,
+        baseUrl: 'https://self-hosted.internal'
+      });
+      expect(svc.getApiEndpoint()).toBe('https://self-hosted.internal/api/v2/llm_request_log_feedbacks');
+    });
+  });
+
+  describe('COOLHAND_BASE_URL environment variable', () => {
+    const envKeys = ['COOLHAND_API_KEY', 'COOLHAND_BASE_URL', 'COOLHAND_SILENT'];
+    const envBackup: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      jest.resetModules();
+      jest.spyOn(console, 'log').mockImplementation();
+      jest.spyOn(console, 'warn').mockImplementation();
+      jest.spyOn(console, 'error').mockImplementation();
+      for (const k of envKeys) { envBackup[k] = process.env[k]; }
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        clone: () => ({ text: () => Promise.resolve('{}') }),
+      }) as any;
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      for (const k of envKeys) {
+        if (envBackup[k] === undefined) { delete process.env[k]; }
+        else { process.env[k] = envBackup[k]; }
+      }
+    });
+
+    it('reads COOLHAND_BASE_URL and uses it as the API host', async () => {
+      process.env.COOLHAND_API_KEY = 'env-key';
+      process.env.COOLHAND_BASE_URL = 'https://self-hosted.example.com';
+
+      await import('../src/auto-monitor');
+      await new Promise(r => setTimeout(r, 50));
+
+      const { getGlobalStats } = await import('../src/global-monitor');
+      expect(getGlobalStats().apiEndpoint).toBe(
+        'https://self-hosted.example.com/api/v2/llm_request_logs'
+      );
+    });
+
+    it('uses the default host when COOLHAND_BASE_URL is not set', async () => {
+      process.env.COOLHAND_API_KEY = 'env-key';
+      delete process.env.COOLHAND_BASE_URL;
+
+      await import('../src/auto-monitor');
+      await new Promise(r => setTimeout(r, 50));
+
+      const { getGlobalStats } = await import('../src/global-monitor');
+      expect(getGlobalStats().apiEndpoint).toBe(
+        'https://coolhandlabs.com/api/v2/llm_request_logs'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What's New

- **`baseUrl` option** — `new Coolhand({ baseUrl })`, `initializeGlobalMonitoring({ baseUrl })`, and `BaseServiceConfig` all accept an optional `baseUrl` to redirect log and feedback POSTs to a self-hosted endpoint. Defaults to `https://coolhandlabs.com` when omitted, so existing integrations are unaffected.
- **`COOLHAND_BASE_URL` env var** — Auto-monitor reads this at startup and forwards it, enabling self-hosted setups with zero code changes.

## What Changed

- `LoggingService` and `FeedbackService` now pass only the path fragment (`/api/v2/…`) to `BaseService`; the full URL is assembled in `BaseService` from `config.baseUrl` + path.
- `BaseService` validates `baseUrl` on construction: `https://` is always allowed; `http://` is allowed only for `localhost`, `127.0.0.1`, `[::1]`, and `*.localhost` (local dev); anything else throws immediately with a descriptive error. Trailing slashes are normalized before path concatenation.

## Breaking Changes

None. The default host is unchanged and all new parameters are optional.

## Version

`0.3.1 → 0.4.0` (additive feature, minor bump per semver).

Closes #33.