### PR TITLE
Add baseUrl option for self-hosted deployments (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,14 @@ const feedback = await coolhand.createFeedback({
 | `silent` | boolean | `true` | Whether to suppress console output |
 | `debug` | boolean | `false` | Enable debug mode (API calls will be mocked) |
 | `patternsFile` | string | `undefined` | Path to custom API patterns file |
+| `baseUrl` | string | `undefined` | Override the API host for self-hosted deployments (e.g. `'https://feedback.example.com'`). Must use `https://`; `http://localhost` is also accepted for local dev. Defaults to `https://coolhandlabs.com`. |
 
 ### Environment Variables
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `COOLHAND_API_KEY` | string | *required* | Your Coolhand API key |
+| `COOLHAND_BASE_URL` | string | `undefined` | Override the API host for self-hosted deployments (e.g. `'https://feedback.example.com'`). Same rules as the `baseUrl` constructor option. |
 | `COOLHAND_SILENT` | `'true'` \| `'false'` | `'true'` | Whether to suppress console output |
 | `COOLHAND_DEBUG` | `'true'` \| `'false'` | `'false'` | Enable debug mode |
 | `COOLHAND_PATTERNS_FILE` | string | `undefined` | Path to custom API patterns file |

--- a/src/auto-monitor.ts
+++ b/src/auto-monitor.ts
@@ -6,6 +6,7 @@
  *
  * Environment Variables:
  * - COOLHAND_API_KEY (required)
+ * - COOLHAND_BASE_URL (optional: custom API host, e.g. 'https://feedback.example.com')
  * - COOLHAND_SILENT (optional: 'true' | 'false', default: 'true')
  * - COOLHAND_PATTERNS_FILE (optional: path to custom patterns file)
  * - COOLHAND_DEBUG (optional: 'true' | 'false', default: 'false')
@@ -29,6 +30,7 @@ if (apiKey) {
   const silent = process.env.COOLHAND_SILENT !== 'false'; // Default to true unless explicitly false
   const patternsFile = process.env.COOLHAND_PATTERNS_FILE;
   const debug = process.env.COOLHAND_DEBUG === 'true'; // Default to false unless explicitly true
+  const baseUrl = process.env.COOLHAND_BASE_URL;
 
   // Async initialization wrapped in IIFE
   (async () => {
@@ -41,7 +43,8 @@ if (apiKey) {
         apiKey,
         silent,
         patternsFile,
-        debug
+        debug,
+        ...(baseUrl ? { baseUrl } : {})
       });
 
       if (!silent) {

--- a/src/coolhand.ts
+++ b/src/coolhand.ts
@@ -27,7 +27,8 @@ export class Coolhand {
     const serviceConfig = {
       apiKey,
       silent: this.silent,
-      debug: options.debug
+      debug: options.debug,
+      baseUrl: options.baseUrl
     };
 
     this.loggingService = new LoggingService(serviceConfig);

--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -89,6 +89,7 @@ interface GlobalMonitorConfig {
   silent?: boolean;
   patternsFile?: string;
   debug?: boolean;
+  baseUrl?: string;
 }
 
 /**
@@ -108,7 +109,8 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
   globalLoggingService = new LoggingService({
     apiKey: config.apiKey,
     silent,
-    debug: config.debug
+    debug: config.debug,
+    baseUrl: config.baseUrl
   });
 
   // Load Node.js modules if available

--- a/src/services/BaseService.ts
+++ b/src/services/BaseService.ts
@@ -27,13 +27,13 @@ export abstract class BaseService {
     if (!parsed.hostname) {
       throw new Error(`baseUrl must include a hostname. Got: ${baseUrl}`);
     }
-    if (parsed.protocol === 'https:') return;
+    if (parsed.protocol === 'https:') { return; }
     if (parsed.protocol === 'http:') {
       const isLocal = parsed.hostname === 'localhost' ||
                       parsed.hostname === '127.0.0.1' ||
                       parsed.hostname === '::1' ||
                       parsed.hostname === '[::1]';
-      if (isLocal) return;
+      if (isLocal) { return; }
       throw new Error(
         `baseUrl must use https:// for non-local hosts. Got: ${baseUrl}\n` +
         `  For local development, http://localhost:... is allowed.`

--- a/src/services/BaseService.ts
+++ b/src/services/BaseService.ts
@@ -6,13 +6,45 @@ export interface BaseServiceConfig {
   apiKey: string;
   silent: boolean;
   debug?: boolean;
+  baseUrl?: string;
 }
 
 export abstract class BaseService {
+  static readonly DEFAULT_BASE_URL = 'https://coolhandlabs.com';
+
   protected apiKey: string;
   protected silent: boolean;
   protected debug: boolean;
   protected apiEndpoint: string;
+
+  static validateBaseUrl(baseUrl: string): void {
+    let parsed: URL;
+    try {
+      parsed = new URL(baseUrl);
+    } catch {
+      throw new Error(`baseUrl must start with https:// or http://localhost. Got: ${baseUrl}`);
+    }
+    if (!parsed.hostname) {
+      throw new Error(`baseUrl must include a hostname. Got: ${baseUrl}`);
+    }
+    if (parsed.protocol === 'https:') return;
+    if (parsed.protocol === 'http:') {
+      const isLocal = parsed.hostname === 'localhost' ||
+                      parsed.hostname === '127.0.0.1' ||
+                      parsed.hostname === '::1' ||
+                      parsed.hostname === '[::1]';
+      if (isLocal) return;
+      throw new Error(
+        `baseUrl must use https:// for non-local hosts. Got: ${baseUrl}\n` +
+        `  For local development, http://localhost:... is allowed.`
+      );
+    }
+    throw new Error(`baseUrl must start with https:// or http://localhost. Got: ${baseUrl}`);
+  }
+
+  static normalizeBaseUrl(baseUrl: string): string {
+    return baseUrl.replace(/\/$/, '');
+  }
 
   constructor(config: BaseServiceConfig, endpoint: string) {
     this.apiKey = config.apiKey;

--- a/src/services/FeedbackService.ts
+++ b/src/services/FeedbackService.ts
@@ -9,7 +9,7 @@ const FEEDBACK_PATH = '/api/v2/llm_request_log_feedbacks';
 export class FeedbackService extends BaseService {
   constructor(config: FeedbackServiceConfig) {
     const base = config.baseUrl ?? BaseService.DEFAULT_BASE_URL;
-    if (config.baseUrl) BaseService.validateBaseUrl(base);
+    if (config.baseUrl) { BaseService.validateBaseUrl(base); }
     super(config, BaseService.normalizeBaseUrl(base) + FEEDBACK_PATH);
   }
 

--- a/src/services/FeedbackService.ts
+++ b/src/services/FeedbackService.ts
@@ -4,9 +4,13 @@ import { BaseService, BaseServiceConfig } from './BaseService.js';
 
 export interface FeedbackServiceConfig extends BaseServiceConfig {}
 
+const FEEDBACK_PATH = '/api/v2/llm_request_log_feedbacks';
+
 export class FeedbackService extends BaseService {
   constructor(config: FeedbackServiceConfig) {
-    super(config, 'https://coolhandlabs.com/api/v2/llm_request_log_feedbacks');
+    const base = config.baseUrl ?? BaseService.DEFAULT_BASE_URL;
+    if (config.baseUrl) BaseService.validateBaseUrl(base);
+    super(config, BaseService.normalizeBaseUrl(base) + FEEDBACK_PATH);
   }
 
   public async createFeedback(feedback: LLMRequestLogFeedback, collectionMethod?: CollectionMethod): Promise<LLMRequestLogFeedbackResponse | null> {

--- a/src/services/LoggingService.ts
+++ b/src/services/LoggingService.ts
@@ -4,9 +4,13 @@ import { BaseService, BaseServiceConfig } from './BaseService.js';
 
 export interface LoggingServiceConfig extends BaseServiceConfig {}
 
+const LOG_PATH = '/api/v2/llm_request_logs';
+
 export class LoggingService extends BaseService {
   constructor(config: LoggingServiceConfig) {
-    super(config, 'https://coolhandlabs.com/api/v2/llm_request_logs');
+    const base = config.baseUrl ?? BaseService.DEFAULT_BASE_URL;
+    if (config.baseUrl) BaseService.validateBaseUrl(base);
+    super(config, BaseService.normalizeBaseUrl(base) + LOG_PATH);
   }
 
   public async logRequestToAPI(callData: CoolhandCallData, matchedPattern?: CoolhandMatchedPattern, collectionMethod?: CollectionMethod): Promise<void> {

--- a/src/services/LoggingService.ts
+++ b/src/services/LoggingService.ts
@@ -9,7 +9,7 @@ const LOG_PATH = '/api/v2/llm_request_logs';
 export class LoggingService extends BaseService {
   constructor(config: LoggingServiceConfig) {
     const base = config.baseUrl ?? BaseService.DEFAULT_BASE_URL;
-    if (config.baseUrl) BaseService.validateBaseUrl(base);
+    if (config.baseUrl) { BaseService.validateBaseUrl(base); }
     super(config, BaseService.normalizeBaseUrl(base) + LOG_PATH);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface CoolhandOptions {
   silent?: boolean;
   patternsFile?: string;
   debug?: boolean;
+  baseUrl?: string;
 }
 
 export interface CoolhandCallData {

--- a/test/integration-config.test.ts
+++ b/test/integration-config.test.ts
@@ -623,3 +623,109 @@ describe('FeedbackService debug mode integration', () => {
     expect(body.llm_request_log_feedback.like).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 11. baseUrl configuration
+// ---------------------------------------------------------------------------
+
+describe('baseUrl configuration', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('Coolhand uses custom baseUrl in logging endpoint', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      const instance = new Coolhand({ apiKey: 'k', baseUrl: 'https://feedback.example.com' });
+      expect(instance.getStats().apiEndpoint).toBe('https://feedback.example.com/api/v2/llm_request_logs');
+    });
+  });
+
+  it('Coolhand uses custom baseUrl in feedback endpoint', async () => {
+    const fetchSpy = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: 1, like: true }),
+    });
+    globalThis.fetch = fetchSpy;
+
+    await jest.isolateModulesAsync(async () => {
+      const { Coolhand } = require('../src/coolhand');
+      const instance = new Coolhand({ apiKey: 'k', baseUrl: 'https://feedback.example.com', debug: false });
+      await instance.createFeedback({ like: true });
+    });
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchSpy.mock.calls[0][0]).toBe('https://feedback.example.com/api/v2/llm_request_log_feedbacks');
+  });
+
+  it('trailing slash on baseUrl is normalized', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      const instance = new Coolhand({ apiKey: 'k', baseUrl: 'https://feedback.example.com/' });
+      expect(instance.getStats().apiEndpoint).toBe('https://feedback.example.com/api/v2/llm_request_logs');
+    });
+  });
+
+  it('accepts https:// baseUrl', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      expect(() => new Coolhand({ apiKey: 'k', baseUrl: 'https://self-hosted.example.com' })).not.toThrow();
+    });
+  });
+
+  it('accepts http://localhost baseUrl', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      expect(() => new Coolhand({ apiKey: 'k', baseUrl: 'http://localhost:8080' })).not.toThrow();
+    });
+  });
+
+  it('accepts http://127.0.0.1 baseUrl', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      expect(() => new Coolhand({ apiKey: 'k', baseUrl: 'http://127.0.0.1:3000' })).not.toThrow();
+    });
+  });
+
+  it('rejects http:// with non-local host', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      expect(() => new Coolhand({ apiKey: 'k', baseUrl: 'http://example.com' })).toThrow('https://');
+    });
+  });
+
+  it('rejects non-http/https scheme', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      expect(() => new Coolhand({ apiKey: 'k', baseUrl: 'ftp://bad.example.com' })).toThrow('https://');
+    });
+  });
+
+  it('rejects malformed https:// with no hostname', () => {
+    jest.isolateModules(() => {
+      const { Coolhand } = require('../src/coolhand');
+      expect(() => new Coolhand({ apiKey: 'k', baseUrl: 'https://' })).toThrow();
+      expect(() => new Coolhand({ apiKey: 'k', baseUrl: 'https:// ' })).toThrow();
+    });
+  });
+
+  it('initializeGlobalMonitoring accepts baseUrl and uses it', async () => {
+    const mod = await import('../src/global-monitor');
+    await mod.initializeGlobalMonitoring({ apiKey: 'k', silent: true, baseUrl: 'https://self-hosted.example.com' });
+    expect(mod.getGlobalStats().apiEndpoint).toBe('https://self-hosted.example.com/api/v2/llm_request_logs');
+  });
+
+  it('COOLHAND_BASE_URL env var is forwarded by auto-monitor', async () => {
+    process.env.COOLHAND_API_KEY = 'auto-test-key';
+    process.env.COOLHAND_BASE_URL = 'https://self-hosted.example.com';
+
+    const mod = await import('../src/auto-monitor');
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(mod.getGlobalStats().apiEndpoint).toBe('https://self-hosted.example.com/api/v2/llm_request_logs');
+
+    delete process.env.COOLHAND_BASE_URL;
+  });
+});


### PR DESCRIPTION
## What's new

- **`baseUrl` option** — `Coolhand` constructor and `initializeGlobalMonitoring` now accept an optional `baseUrl` string to redirect all log and feedback POSTs to a custom backend instead of `https://coolhandlabs.com`.
- **`COOLHAND_BASE_URL` env var** — the `auto-monitor` entry point picks this up automatically, keeping zero-code usage parity with the new option.

## What changed

- `BaseService` gains `static DEFAULT_BASE_URL`, `static validateBaseUrl()`, and `static normalizeBaseUrl()` — shared by both `LoggingService` and `FeedbackService` so the production host is defined in one place.
- `CoolhandOptions` and `GlobalMonitorConfig` each have a new `baseUrl?: string` field; `BaseServiceConfig` also carries it through.
- README Configuration Options and Environment Variables tables updated with the new entries.

## Validation rules

`https://` (any host) and `http://` loopback addresses (`localhost`, `127.0.0.1`, `::1`) are accepted; other `http://` hosts and malformed URLs (e.g. `https://`) are rejected with a descriptive error at construction time. Trailing slashes are normalized automatically. The wire format (`POST /api/v2/llm_request_logs`) is unchanged.

## Breaking changes

None. `baseUrl` is optional; omitting it preserves the existing default behavior exactly.