### PR TITLE
feat: add sentiment field to LLMRequestLogFeedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ const feedback = await coolhand.createFeedback({
   original_output: 'Here is the original LLM response!',
   revised_output: 'Here is the human edit of the original LLM response.',
   explanation: 'Tone of the original response read like AI-generated open source README docs',
-  like: true,
+  sentiment: 'dislike', // preferred over `like`
+  // like: true,        // deprecated — use `sentiment` instead
 });
 ```
 
@@ -190,8 +191,10 @@ const feedback = await coolhand.createFeedback({
 ### Quality Data
 - **`revised_output`** ⭐ *Best Signal* - End user revision of the LLM response. The highest value data for improving quality scores.
 - **`explanation`** 💬 *Medium Signal* - End user explanation of why the response was good or bad. Valuable qualitative data.
-- **`like`** 👍 *Low Signal* - Boolean like/dislike. Lower quality signal but easy for users to provide.
+- **`sentiment`** 👍 *Low Signal* - `"like"`, `"dislike"`, or `"neutral"`. Preferred over `like`. Lower quality signal but easy for users to provide.
+- **`like`** *(deprecated)* - Boolean like/dislike. Use `sentiment` instead.
 - **`creator_unique_id`** 👤 *User Tracking* - Unique ID to match feedback to the end user who created it
+- **`workload_hashid`** 🔗 *Workload Association* - Associate feedback with a specific workload
 
 ## Framework Integration
 

--- a/README.md
+++ b/README.md
@@ -191,8 +191,15 @@ const feedback = await coolhand.createFeedback({
 ### Quality Data
 - **`revised_output`** ⭐ *Best Signal* - End user revision of the LLM response. The highest value data for improving quality scores.
 - **`explanation`** 💬 *Medium Signal* - End user explanation of why the response was good or bad. Valuable qualitative data.
-- **`sentiment`** 👍 *Low Signal* - `"like"`, `"dislike"`, or `"neutral"`. Preferred over `like`. Lower quality signal but easy for users to provide.
-- **`like`** *(deprecated)* - Boolean like/dislike. Use `sentiment` instead.
+- **`sentiment`** 🎭 *Preferred* - String: `'like'`, `'dislike'`, or `'neutral'`. Takes precedence if both `sentiment` and `like` are provided.
+- **`like`** 👍 *Low Signal (Deprecated)* - Boolean: `true` = like, `false` = dislike. Use `sentiment` instead. Automatically converted to `sentiment` before sending.
+
+  | `like` (boolean) | `sentiment` (string) |
+  |------------------|----------------------|
+  | `true`           | `"like"`             |
+  | `false`          | `"dislike"`          |
+  | omitted          | *(no conversion)*    |
+
 - **`creator_unique_id`** 👤 *User Tracking* - Unique ID to match feedback to the end user who created it
 - **`workload_hashid`** 🔗 *Workload Association* - Associate feedback with a specific workload
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,7 @@ const feedback = await coolhand.createFeedback({
   original_output: 'Here is the original LLM response!',
   revised_output: 'Here is the human edit of the original LLM response.',
   explanation: 'Tone of the original response read like AI-generated open source README docs',
-  sentiment: 'dislike', // preferred over `like`
-  // like: true,        // deprecated — use `sentiment` instead
+  sentiment: 'like', // preferred; replaces `like: true`
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coolhand-node",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coolhand-node",
-      "version": "0.3.1",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coolhand-node",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Monitor and LLM API calls for analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/src/services/FeedbackService.ts
+++ b/src/services/FeedbackService.ts
@@ -30,7 +30,8 @@ export class FeedbackService extends BaseService {
   private logFeedbackInfo(feedback: LLMRequestLogFeedback): void {
     if (!this.silent) {
       console.log(`\n📝 CREATING FEEDBACK for LLM Request Log ID: ${feedback.llm_request_log_id}`);
-      console.log(`👍/👎 Like: ${feedback.like}`);
+      const sentimentDisplay = feedback.sentiment ?? (feedback.like === true ? 'like' : feedback.like === false ? 'dislike' : undefined);
+      console.log(`👍/👎 Sentiment: ${sentimentDisplay ?? 'N/A'}`);
       if (feedback.explanation) {
         console.log(`💭 Explanation: ${feedback.explanation.substring(0, 100)}${feedback.explanation.length > 100 ? '...' : ''}`);
       }

--- a/src/services/FeedbackService.ts
+++ b/src/services/FeedbackService.ts
@@ -11,7 +11,8 @@ export class FeedbackService extends BaseService {
 
   private normalizeSentiment(feedback: LLMRequestLogFeedback): LLMRequestLogFeedback {
     if (feedback.sentiment !== undefined || feedback.like === undefined) { return feedback; }
-    return { ...feedback, sentiment: feedback.like ? 'like' : 'dislike' };
+    const { like, ...rest } = feedback;
+    return { ...rest, sentiment: like ? 'like' : 'dislike' };
   }
 
   public async createFeedback(feedback: LLMRequestLogFeedback, collectionMethod?: CollectionMethod): Promise<LLMRequestLogFeedbackResponse | null> {

--- a/src/services/FeedbackService.ts
+++ b/src/services/FeedbackService.ts
@@ -9,14 +9,20 @@ export class FeedbackService extends BaseService {
     super(config, '/api/v2/llm_request_log_feedbacks');
   }
 
+  private normalizeSentiment(feedback: LLMRequestLogFeedback): LLMRequestLogFeedback {
+    if (feedback.sentiment !== undefined || feedback.like === undefined) { return feedback; }
+    return { ...feedback, sentiment: feedback.like ? 'like' : 'dislike' };
+  }
+
   public async createFeedback(feedback: LLMRequestLogFeedback, collectionMethod?: CollectionMethod): Promise<LLMRequestLogFeedbackResponse | null> {
-    const feedbackWithCollector = this.addCollectorToData(feedback, collectionMethod);
+    const normalized = this.normalizeSentiment(feedback);
+    const feedbackWithCollector = this.addCollectorToData(normalized, collectionMethod);
 
     const payload: LLMRequestLogFeedbackPayload = {
       llm_request_log_feedback: feedbackWithCollector
     };
 
-    this.logFeedbackInfo(feedback);
+    this.logFeedbackInfo(normalized);
 
     const result = await this.sendRequest<LLMRequestLogFeedbackResponse>(
       payload,
@@ -30,8 +36,7 @@ export class FeedbackService extends BaseService {
   private logFeedbackInfo(feedback: LLMRequestLogFeedback): void {
     if (!this.silent) {
       console.log(`\n📝 CREATING FEEDBACK for LLM Request Log ID: ${feedback.llm_request_log_id}`);
-      const sentimentDisplay = feedback.sentiment ?? (feedback.like === true ? 'like' : feedback.like === false ? 'dislike' : undefined);
-      console.log(`👍/👎 Sentiment: ${sentimentDisplay ?? 'N/A'}`);
+      console.log(`🎭 Sentiment: ${feedback.sentiment ?? 'N/A'}`);
       if (feedback.explanation) {
         console.log(`💭 Explanation: ${feedback.explanation.substring(0, 100)}${feedback.explanation.length > 100 ? '...' : ''}`);
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ export interface LLMRequestLogFeedbackResponse {
   id: number;
   llm_request_log_id: number;
   /** @deprecated Use `sentiment` instead */
-  like?: boolean;
+  like: boolean;
   sentiment?: "like" | "dislike" | "neutral";
   creator_unique_id?: string;
   workload_hashid?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,11 @@ export interface CoolhandMatchedPattern {
 // Types for LLM Request Log Feedback endpoint
 export interface LLMRequestLogFeedback {
   llm_request_log_id?: number;
-  like: boolean;
+  /** @deprecated Use `sentiment` instead */
+  like?: boolean;
+  sentiment?: "like" | "dislike" | "neutral";
+  creator_unique_id?: string;
+  workload_hashid?: string;
   explanation?: string;
   revised_output?: string;
   llm_provider_unique_id?: string;
@@ -80,7 +84,11 @@ export interface LLMRequestLogFeedbackPayload {
 export interface LLMRequestLogFeedbackResponse {
   id: number;
   llm_request_log_id: number;
-  like: boolean;
+  /** @deprecated Use `sentiment` instead */
+  like?: boolean;
+  sentiment?: "like" | "dislike" | "neutral";
+  creator_unique_id?: string;
+  workload_hashid?: string;
   explanation?: string;
   revised_output?: string;
   llm_provider_unique_id?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ export interface LLMRequestLogFeedbackResponse {
   id: number;
   llm_request_log_id: number;
   /** @deprecated Use `sentiment` instead */
-  like: boolean;
+  like?: boolean;
   sentiment?: "like" | "dislike" | "neutral";
   creator_unique_id?: string;
   workload_hashid?: string;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * Run `npm run sync-version` or `npm run build` to regenerate.
  */
 
-export const PACKAGE_VERSION = '0.3.1';
+export const PACKAGE_VERSION = '0.5.0';
 export const PACKAGE_NAME = 'coolhand-node';
 
 /**

--- a/test/feedback-service.test.ts
+++ b/test/feedback-service.test.ts
@@ -464,5 +464,43 @@ describe('FeedbackService', () => {
       consoleSpy.mockRestore();
     });
   });
+
+  describe('like → sentiment normalization', () => {
+    let capturedRequestBody: any;
+    let service: FeedbackService;
+
+    beforeEach(() => {
+      (global as any).fetch = jest.fn().mockImplementation(async (_input: any, options: any) => {
+        capturedRequestBody = JSON.parse(options.body);
+        return {
+          ok: true,
+          status: 200,
+          json: jest.fn().mockResolvedValue({ id: 1, like: true }),
+          text: jest.fn().mockResolvedValue(JSON.stringify({ id: 1, like: true }))
+        };
+      });
+      service = new FeedbackService({ apiKey: 'test-key', silent: true });
+    });
+
+    it('converts like:true to sentiment:"like"', async () => {
+      await service.createFeedback({ like: true });
+      expect(capturedRequestBody.llm_request_log_feedback.sentiment).toBe('like');
+    });
+
+    it('converts like:false to sentiment:"dislike"', async () => {
+      await service.createFeedback({ like: false });
+      expect(capturedRequestBody.llm_request_log_feedback.sentiment).toBe('dislike');
+    });
+
+    it('does not overwrite an explicit sentiment when like is also provided', async () => {
+      await service.createFeedback({ like: false, sentiment: 'neutral' });
+      expect(capturedRequestBody.llm_request_log_feedback.sentiment).toBe('neutral');
+    });
+
+    it('leaves sentiment undefined when neither like nor sentiment is provided', async () => {
+      await service.createFeedback({ llm_request_log_id: 1 });
+      expect(capturedRequestBody.llm_request_log_feedback.sentiment).toBeUndefined();
+    });
+  });
 });
 

--- a/test/feedback-service.test.ts
+++ b/test/feedback-service.test.ts
@@ -456,7 +456,7 @@ describe('FeedbackService', () => {
 
       const logCalls = consoleSpy.mock.calls.flat().join(' ');
       expect(logCalls).toContain('📝 CREATING FEEDBACK');
-      expect(logCalls).toContain('👍/👎 Sentiment: like');
+      expect(logCalls).toContain('🎭 Sentiment: like');
       expect(logCalls).toContain('💭 Explanation:');
       expect(logCalls).toContain('📤 Sending to:');
       expect(logCalls).toContain('✅ Successfully created feedback');

--- a/test/feedback-service.test.ts
+++ b/test/feedback-service.test.ts
@@ -456,7 +456,7 @@ describe('FeedbackService', () => {
 
       const logCalls = consoleSpy.mock.calls.flat().join(' ');
       expect(logCalls).toContain('📝 CREATING FEEDBACK');
-      expect(logCalls).toContain('👍/👎 Like: true');
+      expect(logCalls).toContain('👍/👎 Sentiment: like');
       expect(logCalls).toContain('💭 Explanation:');
       expect(logCalls).toContain('📤 Sending to:');
       expect(logCalls).toContain('✅ Successfully created feedback');

--- a/test/feedback-service.test.ts
+++ b/test/feedback-service.test.ts
@@ -171,7 +171,8 @@ describe('FeedbackService', () => {
 
       const capturedFeedback = capturedRequestBody.llm_request_log_feedback;
       expect(capturedFeedback.llm_request_log_id).toBe(456);
-      expect(capturedFeedback.like).toBe(true);
+      expect(capturedFeedback.sentiment).toBe('like');
+      expect(capturedFeedback).not.toHaveProperty('like');
       expect(capturedFeedback.explanation).toBe('Test explanation');
       expect(capturedFeedback.revised_output).toBe('Revised output');
     });
@@ -482,14 +483,18 @@ describe('FeedbackService', () => {
       service = new FeedbackService({ apiKey: 'test-key', silent: true });
     });
 
-    it('converts like:true to sentiment:"like"', async () => {
+    it('converts like:true to sentiment:"like" and strips like from payload', async () => {
       await service.createFeedback({ like: true });
-      expect(capturedRequestBody.llm_request_log_feedback.sentiment).toBe('like');
+      const sent = capturedRequestBody.llm_request_log_feedback;
+      expect(sent.sentiment).toBe('like');
+      expect(sent).not.toHaveProperty('like');
     });
 
-    it('converts like:false to sentiment:"dislike"', async () => {
+    it('converts like:false to sentiment:"dislike" and strips like from payload', async () => {
       await service.createFeedback({ like: false });
-      expect(capturedRequestBody.llm_request_log_feedback.sentiment).toBe('dislike');
+      const sent = capturedRequestBody.llm_request_log_feedback;
+      expect(sent.sentiment).toBe('dislike');
+      expect(sent).not.toHaveProperty('like');
     });
 
     it('does not overwrite an explicit sentiment when like is also provided', async () => {

--- a/test/integration-config.test.ts
+++ b/test/integration-config.test.ts
@@ -164,7 +164,8 @@ describe('Coolhand feedback helpers', () => {
 
     // Payload should include collector field
     const body = JSON.parse(opts.body);
-    expect(body.llm_request_log_feedback).toHaveProperty('like', true);
+    expect(body.llm_request_log_feedback).toHaveProperty('sentiment', 'like');
+    expect(body.llm_request_log_feedback).not.toHaveProperty('like');
     expect(body.llm_request_log_feedback).toHaveProperty('collector');
     expect(body.llm_request_log_feedback.collector).toContain('coolhand-node');
   });
@@ -620,6 +621,7 @@ describe('FeedbackService debug mode integration', () => {
 
     expect(fetchSpy).toHaveBeenCalled();
     const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
-    expect(body.llm_request_log_feedback.like).toBe(false);
+    expect(body.llm_request_log_feedback.sentiment).toBe('dislike');
+    expect(body.llm_request_log_feedback).not.toHaveProperty('like');
   });
 });


### PR DESCRIPTION
## What's new

- **`sentiment`** field (`"like" | "dislike" | "neutral"`) added to `LLMRequestLogFeedback` and `LLMRequestLogFeedbackResponse` — the preferred replacement for the boolean `like` field
- **`creator_unique_id`** and **`workload_hashid`** fields added to both interfaces
- `FeedbackService` verbose log now reads `sentiment` first, falling back to `like` for backward compatibility
- README example and field guide updated to show the recommended feedback shape

## What changed

- `like` is now **optional** (`like?: boolean`) and marked `@deprecated` on both request and response interfaces — consumers who read `feedback.like` as `boolean` under strict null checks will need a guard
- `LLMRequestLogFeedbackResponse` now mirrors the request shape (previously `like` was required and the new fields were absent)

## Breaking changes (0.x minor)

`like` changed from required to optional. Any TypeScript code that reads `feedback.like` and expects a `boolean` (not `boolean | undefined`) will need a null-guard after upgrading.