### PR TITLE
feat: dual CJS+ESM build — require() support for CommonJS projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install coolhand-node
 
 **Set it and forget it! Monitor ALL AI API calls across your entire application with just one line of code, so you'll never be surprised by new LLM calls added to your production codebase.**
 
-> **Important:** `coolhand-node` is an **ES module** package. See [Module System Compatibility](#module-system-compatibility) for setup in CommonJS environments.
+> **Note:** `coolhand-node` ships both ESM and CommonJS builds. See [Module System Compatibility](#module-system-compatibility) for details.
 
 **ESM projects** (`"type": "module"` in package.json):
 
@@ -98,7 +98,7 @@ const monitor = new Coolhand({
 
 ## Module System Compatibility
 
-`coolhand-node` is published as an **ES module** (`"type": "module"`). How you import it depends on your project's module system.
+`coolhand-node` ships both **ESM** and **CommonJS** builds, so it works in any Node.js project regardless of module system.
 
 ### ESM Projects
 
@@ -112,12 +112,16 @@ import 'coolhand-node/auto-monitor';
 
 ### CommonJS Projects
 
-If your project uses CommonJS (no `"type": "module"`, or `.cjs` files), you cannot use `require()` with this package. Use dynamic `import()` inside an async function:
+If your project uses CommonJS (no `"type": "module"`, or `.cjs` files), `require()` works directly:
 
 ```javascript
+// Zero-config auto-monitor
+require('coolhand-node/auto-monitor');
+
+// Or manual initialization
+const { initializeGlobalMonitoring } = require('coolhand-node');
+
 async function startServer() {
-  // Dynamic import works in CJS
-  const { initializeGlobalMonitoring } = await import('coolhand-node');
   await initializeGlobalMonitoring({
     apiKey: process.env.COOLHAND_API_KEY,
     silent: true
@@ -131,25 +135,24 @@ startServer();
 
 ### TypeScript Compiling to CommonJS
 
-If your `tsconfig.json` has `"module": "commonjs"`, TypeScript converts `await import()` into `require()` at compile time, which will fail. Use the `new Function` workaround to emit a native ESM `import()`:
+If your `tsconfig.json` has `"module": "commonjs"`, `require()` works directly — no workarounds needed:
 
 ```typescript
+// Zero-config auto-monitor
+require('coolhand-node/auto-monitor');
+
+// Or manual initialization
+const { initializeGlobalMonitoring } = require('coolhand-node');
+
 async function startServer() {
-  if (process.env.COOLHAND_API_KEY) {
-    // new Function emits a native import() that survives CJS compilation
-    const _import = new Function('m', 'return import(m)');
-    const { initializeGlobalMonitoring } = await _import('coolhand-node');
-    await initializeGlobalMonitoring({
-      apiKey: process.env.COOLHAND_API_KEY,
-      silent: true
-    });
-  }
+  await initializeGlobalMonitoring({
+    apiKey: process.env.COOLHAND_API_KEY,
+    silent: true
+  });
 
   // ... start your server
 }
 ```
-
-> **Tip:** If your tsconfig uses `"module": "ES2020"`, `"ESNext"`, or `"NodeNext"`, TypeScript preserves the native `import()` and you can use `await import('coolhand-node')` directly without the workaround.
 
 See the [framework guides](#framework-integration) for complete examples.
 

--- a/README.md
+++ b/README.md
@@ -115,13 +115,18 @@ import 'coolhand-node/auto-monitor';
 
 ### CommonJS Projects
 
-If your project uses CommonJS (no `"type": "module"`, or `.cjs` files), `require()` works directly:
+If your project uses CommonJS (no `"type": "module"`, or `.cjs` files), `require()` works directly.
+
+**Option A — zero-config auto-monitor** (reads `COOLHAND_API_KEY` from the environment):
 
 ```javascript
-// Zero-config auto-monitor
 require('coolhand-node/auto-monitor');
+// That's it — all AI API calls are now monitored
+```
 
-// Or manual initialization
+**Option B — manual initialization** (explicit control over options):
+
+```javascript
 const { initializeGlobalMonitoring } = require('coolhand-node');
 
 async function startServer() {
@@ -138,13 +143,17 @@ startServer();
 
 ### TypeScript Compiling to CommonJS
 
-If your `tsconfig.json` has `"module": "commonjs"`, `require()` works directly — no workarounds needed:
+If your `tsconfig.json` has `"module": "commonjs"`, `require()` works directly — no workarounds needed.
+
+**Option A — zero-config auto-monitor**:
 
 ```typescript
-// Zero-config auto-monitor
 require('coolhand-node/auto-monitor');
+```
 
-// Or manual initialization
+**Option B — manual initialization**:
+
+```typescript
 const { initializeGlobalMonitoring } = require('coolhand-node');
 
 async function startServer() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coolhand-node",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coolhand-node",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -19,6 +19,7 @@
         "jest": "^30.2.0",
         "ts-jest": "^29.4.4",
         "ts-node": "^10.9.0",
+        "tsup": "^8.5.1",
         "typescript": "^5.0.0"
       },
       "engines": {
@@ -577,6 +578,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1417,6 +1860,356 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
@@ -2139,9 +2932,9 @@
       ]
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2235,6 +3028,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -2470,6 +3270,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2536,6 +3362,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ci-info": {
@@ -2677,12 +3519,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2825,6 +3694,48 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -3332,6 +4243,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
       }
     },
     "node_modules/flat-cache": {
@@ -4430,6 +5353,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4539,12 +5472,35 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -4581,6 +5537,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -4706,12 +5672,37 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.3",
@@ -4778,6 +5769,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/once": {
@@ -4972,6 +5973,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5013,6 +6021,61 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/prelude-ls": {
@@ -5108,6 +6171,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5150,6 +6227,51 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -5447,6 +6569,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5537,6 +6682,84 @@
         "node": "*"
       }
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -5557,6 +6780,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -5569,6 +6802,13 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/ts-jest": {
       "version": "29.4.4",
@@ -5701,6 +6941,69 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5750,6 +7053,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "sync-version": "node scripts/sync-version.mjs",
     "build": "npm run sync-version && tsup && node scripts/fix-cjs-imports.cjs && cp src/api-patterns.json dist/",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run typecheck && npm run build",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lint:fix": "eslint src test --ext .ts --fix",
     "dev": "tsc --watch",
     "clean": "rm -rf dist coverage",
+    "test:esm": "node scripts/verify-esm.mjs",
     "test:cjs": "node scripts/verify-cjs.cjs",
     "example": "node examples/basic.js"
   },

--- a/package.json
+++ b/package.json
@@ -7,14 +7,24 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./auto-monitor": {
-      "types": "./dist/auto-monitor.d.ts",
-      "import": "./dist/auto-monitor.js",
-      "require": "./dist/auto-monitor.cjs"
+      "import": {
+        "types": "./dist/auto-monitor.d.ts",
+        "default": "./dist/auto-monitor.js"
+      },
+      "require": {
+        "types": "./dist/auto-monitor.d.cts",
+        "default": "./dist/auto-monitor.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./auto-monitor": {
       "types": "./dist/auto-monitor.d.ts",
-      "import": "./dist/auto-monitor.js"
+      "import": "./dist/auto-monitor.js",
+      "require": "./dist/auto-monitor.cjs"
     },
     "./package.json": "./package.json"
   },
@@ -45,7 +47,7 @@
   ],
   "scripts": {
     "sync-version": "node scripts/sync-version.mjs",
-    "build": "npm run sync-version && tsc && cp src/api-patterns.json dist/",
+    "build": "npm run sync-version && tsup && cp src/api-patterns.json dist/",
     "prepublishOnly": "npm run build",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -55,6 +57,7 @@
     "lint:fix": "eslint src test --ext .ts --fix",
     "dev": "tsc --watch",
     "clean": "rm -rf dist coverage",
+    "test:cjs": "node scripts/verify-cjs.cjs",
     "example": "node examples/basic.js"
   },
   "devDependencies": {
@@ -68,6 +71,7 @@
     "jest": "^30.2.0",
     "ts-jest": "^29.4.4",
     "ts-node": "^10.9.0",
+    "tsup": "^8.5.1",
     "typescript": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "sync-version": "node scripts/sync-version.mjs",
-    "build": "npm run sync-version && tsup && cp src/api-patterns.json dist/",
+    "build": "npm run sync-version && tsup && node scripts/fix-cjs-imports.cjs && cp src/api-patterns.json dist/",
     "prepublishOnly": "npm run build",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/scripts/fix-cjs-imports.cjs
+++ b/scripts/fix-cjs-imports.cjs
@@ -1,0 +1,22 @@
+'use strict';
+// tsup bundle:false leaves relative .js paths in require() calls of .cjs output.
+// With "type":"module" in package.json, Node treats those .js files as ESM and fails
+// to load them from a CJS context. This script rewrites the paths in-place.
+const { readFileSync, writeFileSync, readdirSync, statSync } = require('fs');
+const { join } = require('path');
+
+function fixDir(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      fixDir(full);
+    } else if (entry.endsWith('.cjs')) {
+      const original = readFileSync(full, 'utf8');
+      // Only rewrite relative paths (starting with ./ or ../) — leave package imports alone
+      const fixed = original.replace(/require\("(\.[^"]+)\.js"\)/g, 'require("$1.cjs")');
+      if (fixed !== original) writeFileSync(full, fixed);
+    }
+  }
+}
+
+fixDir(join(__dirname, '..', 'dist'));

--- a/scripts/verify-cjs.cjs
+++ b/scripts/verify-cjs.cjs
@@ -1,26 +1,30 @@
 'use strict';
+const assert = require('node:assert/strict');
 
 // Smoke-test that the CJS build exports the expected symbols and works end-to-end
 const pkg = require('../dist/index.cjs');
 
-console.assert(typeof pkg.default === 'function', 'Coolhand class should be default export');
-console.assert(typeof pkg.initializeGlobalMonitoring === 'function', 'initializeGlobalMonitoring should be exported');
-console.assert(typeof pkg.getGlobalStats === 'function', 'getGlobalStats should be exported');
-console.assert(typeof pkg.isGlobalMonitoringActive === 'function', 'isGlobalMonitoringActive should be exported');
-console.assert(typeof pkg.PatternMatchingService === 'function', 'PatternMatchingService should be exported');
+assert.equal(typeof pkg.default, 'function', 'Coolhand class should be default export');
+assert.equal(typeof pkg.initializeGlobalMonitoring, 'function', 'initializeGlobalMonitoring should be exported');
+assert.equal(typeof pkg.getGlobalStats, 'function', 'getGlobalStats should be exported');
+assert.equal(typeof pkg.isGlobalMonitoringActive, 'function', 'isGlobalMonitoringActive should be exported');
+assert.equal(typeof pkg.PatternMatchingService, 'function', 'PatternMatchingService should be exported');
 
 // Verify that api-patterns.json is found and loaded correctly.
 // getPatternsCountSync() === 0 means the JSON was not found (bundling path regression).
 const svc = new pkg.PatternMatchingService({ silent: true });
 const count = svc.getPatternsCountSync();
-console.assert(count > 0, `PatternMatchingService loaded ${count} patterns — expected > 0 (api-patterns.json not found?)`);
+assert.ok(count > 0, `PatternMatchingService loaded ${count} patterns — expected > 0 (api-patterns.json not found?)`);
 
 // Verify that at least one well-known AI domain actually matches
 const match = svc.matchesAPIPatternSync('https://api.openai.com/v1/chat/completions');
-console.assert(match !== null, 'Expected api.openai.com to match a pattern');
-console.assert(match && match.pattern.name === 'OpenAI', `Expected pattern name "OpenAI", got "${match && match.pattern.name}"`);
+assert.notEqual(match, null, 'Expected api.openai.com to match a pattern');
+assert.equal(match.pattern.name, 'OpenAI', `Expected pattern name "OpenAI", got "${match.pattern.name}"`);
 
-// auto-monitor: just require it (triggers env-var check, no assertion needed beyond no throw)
+// Verify singleton: auto-monitor's initialisation should be visible via the index entry point.
+// (This would silently fail if bundle:true duplicated global-monitor state.)
 require('../dist/auto-monitor.cjs');
+const stats = pkg.getGlobalStats();
+assert.equal(typeof stats, 'object', 'getGlobalStats() should return an object after auto-monitor is loaded');
 
 console.log(`CJS smoke test passed (${count} patterns loaded, OpenAI matched)`);

--- a/scripts/verify-cjs.cjs
+++ b/scripts/verify-cjs.cjs
@@ -1,7 +1,6 @@
 'use strict';
 const assert = require('node:assert/strict');
 
-// Smoke-test that the CJS build exports the expected symbols and works end-to-end
 const pkg = require('../dist/index.cjs');
 
 assert.equal(typeof pkg.default, 'function', 'Coolhand class should be default export');
@@ -10,21 +9,25 @@ assert.equal(typeof pkg.getGlobalStats, 'function', 'getGlobalStats should be ex
 assert.equal(typeof pkg.isGlobalMonitoringActive, 'function', 'isGlobalMonitoringActive should be exported');
 assert.equal(typeof pkg.PatternMatchingService, 'function', 'PatternMatchingService should be exported');
 
-// Verify that api-patterns.json is found and loaded correctly.
+// Verify api-patterns.json is found and loaded correctly.
 // getPatternsCountSync() === 0 means the JSON was not found (bundling path regression).
 const svc = new pkg.PatternMatchingService({ silent: true });
 const count = svc.getPatternsCountSync();
 assert.ok(count > 0, `PatternMatchingService loaded ${count} patterns — expected > 0 (api-patterns.json not found?)`);
 
-// Verify that at least one well-known AI domain actually matches
+// Verify a well-known AI domain matches
 const match = svc.matchesAPIPatternSync('https://api.openai.com/v1/chat/completions');
 assert.notEqual(match, null, 'Expected api.openai.com to match a pattern');
 assert.equal(match.pattern.name, 'OpenAI', `Expected pattern name "OpenAI", got "${match.pattern.name}"`);
 
-// Verify singleton: auto-monitor's initialisation should be visible via the index entry point.
-// (This would silently fail if bundle:true duplicated global-monitor state.)
-require('../dist/auto-monitor.cjs');
-const stats = pkg.getGlobalStats();
-assert.equal(typeof stats, 'object', 'getGlobalStats() should return an object after auto-monitor is loaded');
+// Singleton test: initialise via auto-monitor's exported function, then assert the
+// state is visible from the index entry point. Without a shared global-monitor
+// module instance this cross-entry check would return false.
+(async () => {
+  const autoMonitor = require('../dist/auto-monitor.cjs');
+  await autoMonitor.initializeGlobalMonitoring({ apiKey: 'smoke-test-key', silent: true, dryRun: true });
+  assert.equal(pkg.isGlobalMonitoringActive(), true,
+    'index entry should see active state initialised via auto-monitor (shared singleton)');
 
-console.log(`CJS smoke test passed (${count} patterns loaded, OpenAI matched)`);
+  console.log(`CJS smoke test passed (${count} patterns loaded, OpenAI matched)`);
+})().catch(err => { console.error(err); process.exitCode = 1; });

--- a/scripts/verify-cjs.cjs
+++ b/scripts/verify-cjs.cjs
@@ -1,0 +1,26 @@
+'use strict';
+
+// Smoke-test that the CJS build exports the expected symbols and works end-to-end
+const pkg = require('../dist/index.cjs');
+
+console.assert(typeof pkg.default === 'function', 'Coolhand class should be default export');
+console.assert(typeof pkg.initializeGlobalMonitoring === 'function', 'initializeGlobalMonitoring should be exported');
+console.assert(typeof pkg.getGlobalStats === 'function', 'getGlobalStats should be exported');
+console.assert(typeof pkg.isGlobalMonitoringActive === 'function', 'isGlobalMonitoringActive should be exported');
+console.assert(typeof pkg.PatternMatchingService === 'function', 'PatternMatchingService should be exported');
+
+// Verify that api-patterns.json is found and loaded correctly.
+// getPatternsCountSync() === 0 means the JSON was not found (bundling path regression).
+const svc = new pkg.PatternMatchingService({ silent: true });
+const count = svc.getPatternsCountSync();
+console.assert(count > 0, `PatternMatchingService loaded ${count} patterns — expected > 0 (api-patterns.json not found?)`);
+
+// Verify that at least one well-known AI domain actually matches
+const match = svc.matchesAPIPatternSync('https://api.openai.com/v1/chat/completions');
+console.assert(match !== null, 'Expected api.openai.com to match a pattern');
+console.assert(match && match.pattern.name === 'OpenAI', `Expected pattern name "OpenAI", got "${match && match.pattern.name}"`);
+
+// auto-monitor: just require it (triggers env-var check, no assertion needed beyond no throw)
+require('../dist/auto-monitor.cjs');
+
+console.log(`CJS smoke test passed (${count} patterns loaded, OpenAI matched)`);

--- a/scripts/verify-esm.mjs
+++ b/scripts/verify-esm.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+
+// Smoke-test that the ESM build exports the expected symbols and works end-to-end
+import pkg from '../dist/index.js';
+import { initializeGlobalMonitoring, getGlobalStats, isGlobalMonitoringActive, PatternMatchingService } from '../dist/index.js';
+
+assert.equal(typeof pkg, 'function', 'default export should be the Coolhand class');
+assert.equal(typeof initializeGlobalMonitoring, 'function', 'initializeGlobalMonitoring should be exported');
+assert.equal(typeof getGlobalStats, 'function', 'getGlobalStats should be exported');
+assert.equal(typeof isGlobalMonitoringActive, 'function', 'isGlobalMonitoringActive should be exported');
+assert.equal(typeof PatternMatchingService, 'function', 'PatternMatchingService should be exported');
+
+// Verify api-patterns.json is found and patterns load correctly
+const svc = new PatternMatchingService({ silent: true });
+const count = svc.getPatternsCountSync();
+assert.ok(count > 0, `PatternMatchingService loaded ${count} patterns — expected > 0 (api-patterns.json not found?)`);
+
+// Verify a well-known AI domain matches
+const match = svc.matchesAPIPatternSync('https://api.openai.com/v1/chat/completions');
+assert.notEqual(match, null, 'Expected api.openai.com to match a pattern');
+assert.equal(match.pattern.name, 'OpenAI', `Expected pattern name "OpenAI", got "${match.pattern.name}"`);
+
+// Verify singleton: auto-monitor's initialisation should be visible via the index entry point
+await import('../dist/auto-monitor.js');
+const stats = getGlobalStats();
+assert.equal(typeof stats, 'object', 'getGlobalStats() should return an object after auto-monitor is loaded');
+
+console.log(`ESM smoke test passed (${count} patterns loaded, OpenAI matched)`);

--- a/scripts/verify-esm.mjs
+++ b/scripts/verify-esm.mjs
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict';
 
-// Smoke-test that the ESM build exports the expected symbols and works end-to-end
 import pkg from '../dist/index.js';
 import { initializeGlobalMonitoring, getGlobalStats, isGlobalMonitoringActive, PatternMatchingService } from '../dist/index.js';
 
@@ -10,7 +9,8 @@ assert.equal(typeof getGlobalStats, 'function', 'getGlobalStats should be export
 assert.equal(typeof isGlobalMonitoringActive, 'function', 'isGlobalMonitoringActive should be exported');
 assert.equal(typeof PatternMatchingService, 'function', 'PatternMatchingService should be exported');
 
-// Verify api-patterns.json is found and patterns load correctly
+// Verify api-patterns.json is found and loaded correctly.
+// getPatternsCountSync() === 0 means the JSON was not found (bundling path regression).
 const svc = new PatternMatchingService({ silent: true });
 const count = svc.getPatternsCountSync();
 assert.ok(count > 0, `PatternMatchingService loaded ${count} patterns — expected > 0 (api-patterns.json not found?)`);
@@ -20,9 +20,12 @@ const match = svc.matchesAPIPatternSync('https://api.openai.com/v1/chat/completi
 assert.notEqual(match, null, 'Expected api.openai.com to match a pattern');
 assert.equal(match.pattern.name, 'OpenAI', `Expected pattern name "OpenAI", got "${match.pattern.name}"`);
 
-// Verify singleton: auto-monitor's initialisation should be visible via the index entry point
-await import('../dist/auto-monitor.js');
-const stats = getGlobalStats();
-assert.equal(typeof stats, 'object', 'getGlobalStats() should return an object after auto-monitor is loaded');
+// Singleton test: initialise via auto-monitor's exported function, then assert the
+// state is visible from the index entry point. Without a shared global-monitor
+// module instance this cross-entry check would return false.
+const autoMonitor = await import('../dist/auto-monitor.js');
+await autoMonitor.initializeGlobalMonitoring({ apiKey: 'smoke-test-key', silent: true, dryRun: true });
+assert.equal(isGlobalMonitoringActive(), true,
+  'index entry should see active state initialised via auto-monitor (shared singleton)');
 
 console.log(`ESM smoke test passed (${count} patterns loaded, OpenAI matched)`);

--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -62,19 +62,43 @@ const loadNodeModules = async () => {
   }
 };
 
-// Global state for the monitoring system
-let globalPatternService: PatternMatchingService | null = null;
-let globalLoggingService: LoggingService | null = null;
-let isGloballyPatched = false;
-let callCounter = 0;
-let interceptedCalls = 0;
-let silent = true;
+// State is stored on globalThis so both the CJS and ESM builds of this module
+// share the same values in a mixed-format Node.js process. A string key (not a
+// Symbol) is required because Symbols are per-realm and would be independent
+// across module formats.
+const COOLHAND_STATE_KEY = '__coolhand_node_v1__';
 
-// Global deduplication registry
-const globalActiveRequests = new Map<string, {
-  timestamp: number;
-  requestIds: Set<string>;
-}>();
+interface CoolhandGlobalState {
+  globalPatternService: PatternMatchingService | null;
+  globalLoggingService: LoggingService | null;
+  isGloballyPatched: boolean;
+  callCounter: number;
+  interceptedCalls: number;
+  silent: boolean;
+  globalActiveRequests: Map<string, { timestamp: number; requestIds: Set<string> }>;
+}
+
+function getState(): CoolhandGlobalState {
+  const g = globalThis as any;
+  if (!g[COOLHAND_STATE_KEY]) {
+    g[COOLHAND_STATE_KEY] = {
+      globalPatternService: null,
+      globalLoggingService: null,
+      isGloballyPatched: false,
+      callCounter: 0,
+      interceptedCalls: 0,
+      silent: true,
+      globalActiveRequests: new Map(),
+    } satisfies CoolhandGlobalState;
+  }
+  return g[COOLHAND_STATE_KEY] as CoolhandGlobalState;
+}
+
+/** Reset all singleton state — for use in tests only. */
+export function _resetGlobalState(): void {
+  delete (globalThis as any)[COOLHAND_STATE_KEY];
+}
+
 const DEDUP_WINDOW_MS = 1000;
 
 interface GlobalMonitorConfig {
@@ -91,12 +115,14 @@ interface GlobalMonitorConfig {
  * This should be called once at the start of your application
  */
 export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): Promise<void> {
-  if (isGloballyPatched) {
+  const state = getState();
+
+  if (state.isGloballyPatched) {
     log('🔄 Global monitoring already initialized, skipping...');
     return;
   }
 
-  silent = config.silent !== false;
+  state.silent = config.silent !== false;
 
   if (config.debug && !config.dryRun) {
     console.warn(
@@ -107,10 +133,10 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
   }
 
   // Initialize services
-  globalPatternService = new PatternMatchingService({ customPatternsFile: config.patternsFile, silent });
-  globalLoggingService = new LoggingService({
+  state.globalPatternService = new PatternMatchingService({ customPatternsFile: config.patternsFile, silent: state.silent });
+  state.globalLoggingService = new LoggingService({
     apiKey: config.apiKey,
-    silent,
+    silent: state.silent,
     debug: config.debug,
     dryRun: config.dryRun,
     baseUrl: config.baseUrl
@@ -126,9 +152,9 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
   }
   patchFetch(); // Always available
 
-  isGloballyPatched = true;
+  state.isGloballyPatched = true;
 
-  if (!silent) {
+  if (!state.silent) {
     console.log('🌐 Global Coolhand monitoring initialized');
     if (config.dryRun) {
       console.log('🚫 Dry run mode: ON — API calls will be skipped');
@@ -136,8 +162,8 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
     if (config.debug) {
       console.log('🔬 Debug mode: ON — verbose logging enabled');
     }
-    console.log(`🎯 API Endpoint: ${globalLoggingService.getApiEndpoint()}`);
-    console.log(`📋 Loaded ${await globalPatternService.getPatternsCount()} AI API patterns`);
+    console.log(`🎯 API Endpoint: ${state.globalLoggingService.getApiEndpoint()}`);
+    console.log(`📋 Loaded ${await state.globalPatternService.getPatternsCount()} AI API patterns`);
     console.log(`🔍 Monitoring mode: ${hasNodeModules ? 'Full (HTTP/HTTPS/Fetch)' : 'Fetch only (Edge runtime)'}`);
   }
 }
@@ -146,11 +172,12 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
  * Get global monitoring statistics
  */
 export function getGlobalStats() {
+  const state = getState();
   return {
-    totalRequests: callCounter,
-    interceptedCalls: interceptedCalls,
-    apiEndpoint: globalLoggingService?.getApiEndpoint() || 'Not initialized',
-    isInitialized: isGloballyPatched
+    totalRequests: state.callCounter,
+    interceptedCalls: state.interceptedCalls,
+    apiEndpoint: state.globalLoggingService?.getApiEndpoint() || 'Not initialized',
+    isInitialized: state.isGloballyPatched
   };
 }
 
@@ -158,7 +185,7 @@ export function getGlobalStats() {
  * Check if global monitoring is active
  */
 export function isGlobalMonitoringActive(): boolean {
-  return isGloballyPatched;
+  return getState().isGloballyPatched;
 }
 
 function generateRequestId(options: CoolhandRequestOptions | string | URL, method: string): string {
@@ -167,12 +194,13 @@ function generateRequestId(options: CoolhandRequestOptions | string | URL, metho
 }
 
 function isRequestActive(requestId: string): boolean {
-  const active = globalActiveRequests.get(requestId);
+  const state = getState();
+  const active = state.globalActiveRequests.get(requestId);
   if (!active) {return false;}
 
   const now = Date.now();
   if (now - active.timestamp > DEDUP_WINDOW_MS) {
-    globalActiveRequests.delete(requestId);
+    state.globalActiveRequests.delete(requestId);
     return false;
   }
 
@@ -180,14 +208,15 @@ function isRequestActive(requestId: string): boolean {
 }
 
 function registerActiveRequest(requestId: string): string {
+  const state = getState();
   const uniqueId = `${requestId}-${Date.now()}-${Math.random()}`;
   const now = Date.now();
 
-  const existing = globalActiveRequests.get(requestId);
+  const existing = state.globalActiveRequests.get(requestId);
   if (existing) {
     existing.requestIds.add(uniqueId);
   } else {
-    globalActiveRequests.set(requestId, {
+    state.globalActiveRequests.set(requestId, {
       timestamp: now,
       requestIds: new Set([uniqueId])
     });
@@ -197,11 +226,12 @@ function registerActiveRequest(requestId: string): string {
 }
 
 function unregisterActiveRequest(requestId: string, uniqueId: string): void {
-  const active = globalActiveRequests.get(requestId);
+  const state = getState();
+  const active = state.globalActiveRequests.get(requestId);
   if (active) {
     active.requestIds.delete(uniqueId);
     if (active.requestIds.size === 0) {
-      globalActiveRequests.delete(requestId);
+      state.globalActiveRequests.delete(requestId);
     }
   }
 }
@@ -217,6 +247,7 @@ function patchHTTPS(): void {
         value: function(options: CoolhandRequestOptions | string | URL, callback?: (res: HttpIncomingMessage) => void) {
           debugRequest('HTTPS REQUEST', options);
 
+          const { globalPatternService } = getState();
           if (!globalPatternService) {
             return originalRequest.call(this, options as any, callback as any);
           }
@@ -255,6 +286,7 @@ function patchHTTPS(): void {
         value: function(options: CoolhandRequestOptions | string | URL, callback?: (res: HttpIncomingMessage) => void) {
           debugRequest('HTTPS GET', options);
 
+          const { globalPatternService } = getState();
           if (!globalPatternService) {
             return originalGet.call(this, options as any, callback as any);
           }
@@ -297,6 +329,7 @@ function patchHTTP(): void {
         value: function(options: CoolhandRequestOptions | string | URL, callback?: (res: HttpIncomingMessage) => void) {
           debugRequest('HTTP REQUEST', options);
 
+          const { globalPatternService } = getState();
           if (!globalPatternService) {
             return originalRequest.call(this, options as any, callback as any);
           }
@@ -335,6 +368,7 @@ function patchHTTP(): void {
         value: function(options: CoolhandRequestOptions | string | URL, callback?: (res: HttpIncomingMessage) => void) {
           debugRequest('HTTP GET', options);
 
+          const { globalPatternService } = getState();
           if (!globalPatternService) {
             return originalGet.call(this, options as any, callback as any);
           }
@@ -374,6 +408,7 @@ function patchFetch(): void {
       const urlStr = typeof url === 'string' ? url : url.toString();
       debugRequest('FETCH', { url: urlStr, ...options });
 
+      const { globalPatternService } = getState();
       if (!globalPatternService) {
         return originalFetch.call(this, url, options);
       }
@@ -406,7 +441,8 @@ function interceptRequest(
   protocol: 'https' | 'http' = 'https',
   matchedPattern?: CoolhandMatchedPattern
 ): HttpClientRequest {
-  interceptedCalls++;
+  const state = getState();
+  state.interceptedCalls++;
 
   const method = typeof options === 'object' && 'method' in options ? options.method || 'GET' : 'GET';
   const url = buildURL(options, protocol);
@@ -414,11 +450,11 @@ function interceptRequest(
   const uniqueId = registerActiveRequest(requestId);
 
   const callData: CoolhandCallData = {
-    id: interceptedCalls,
+    id: state.interceptedCalls,
     timestamp: new Date().toISOString(),
     method: method,
     url: url,
-    headers: globalPatternService?.sanitizeHeaders(
+    headers: state.globalPatternService?.sanitizeHeaders(
       typeof options === 'object' && 'headers' in options ? options.headers || {} : {},
       matchedPattern?.pattern
     ) || {},
@@ -452,12 +488,13 @@ function interceptRequest(
         log(`⚠️ Response body capture failed for call #${callData.id}: ${err?.message}`);
         callData.response_body = null;
       }
-      callData.response_headers = globalPatternService?.sanitizeHeaders(res.headers, matchedPattern?.pattern) || {};
+      const s = getState();
+      callData.response_headers = s.globalPatternService?.sanitizeHeaders(res.headers, matchedPattern?.pattern) || {};
       callData.status_code = res.statusCode || null;
 
       // Log to API
-      if (globalLoggingService) {
-        globalLoggingService.logRequestToAPI(callData, matchedPattern, 'global-monitoring');
+      if (s.globalLoggingService) {
+        s.globalLoggingService.logRequestToAPI(callData, matchedPattern, 'global-monitoring');
       }
 
       // Cleanup
@@ -501,7 +538,8 @@ async function interceptFetch(
   options: RequestInit,
   matchedPattern?: CoolhandMatchedPattern
 ): Promise<Response> {
-  interceptedCalls++;
+  const state = getState();
+  state.interceptedCalls++;
 
   const method = options.method || 'GET';
   const urlStr = url.toString();
@@ -509,11 +547,11 @@ async function interceptFetch(
   const uniqueId = registerActiveRequest(requestId);
 
   const callData: CoolhandCallData = {
-    id: interceptedCalls,
+    id: state.interceptedCalls,
     timestamp: new Date().toISOString(),
     method: method,
     url: urlStr,
-    headers: globalPatternService?.sanitizeHeaders(
+    headers: state.globalPatternService?.sanitizeHeaders(
       options.headers instanceof Headers
         ? Object.fromEntries(options.headers.entries())
         : (options.headers || {}),
@@ -540,8 +578,9 @@ async function interceptFetch(
     callData.response_body = parseBody(responseText);
 
     // Log to API
-    if (globalLoggingService) {
-      globalLoggingService.logRequestToAPI(callData, matchedPattern, 'global-monitoring');
+    const s = getState();
+    if (s.globalLoggingService) {
+      s.globalLoggingService.logRequestToAPI(callData, matchedPattern, 'global-monitoring');
     }
 
     // Cleanup
@@ -581,11 +620,11 @@ function debugRequest(type: string, options: CoolhandRequestOptions | string | U
   log(`🌐 ${type} to: ${hostname}`);
 
   // Count all requests
-  callCounter++;
+  getState().callCounter++;
 }
 
 function log(...args: any[]): void {
-  if (!silent) {
+  if (!getState().silent) {
     console.log(...args);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Coolhand } from './coolhand.js';
 export { Coolhand };
 export * from './types.js';
 export * from './services/index.js';
-export * from './global-monitor.js';
+export { initializeGlobalMonitoring, getGlobalStats, isGlobalMonitoringActive } from './global-monitor.js';
 export * from './utils/collector.js';
 export * from './utils/parse-body.js';
 export * from './version.js';

--- a/src/services/PatternMatchingService.ts
+++ b/src/services/PatternMatchingService.ts
@@ -242,7 +242,13 @@ export class PatternMatchingService {
             baseDir = process.cwd();
           }
         }
-        patternsFile = _path.join(baseDir, '..', 'api-patterns.json');
+        // Try the current directory first (tsup bundle: dist/index.cjs → baseDir = dist/).
+        // Fall back to the parent directory (tsc/Jest source: src/services/ → need ../ to reach src/).
+        const candidates: string[] = [
+          _path.join(baseDir, 'api-patterns.json'),
+          _path.join(baseDir, '..', 'api-patterns.json'),
+        ];
+        patternsFile = candidates.find((p: string) => fs.existsSync(p)) || candidates[0];
       }
 
       if (fs.existsSync(patternsFile)) {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,4 @@
 export { PatternMatchingService } from './PatternMatchingService.js';
 export { RequestMonitoringService } from './RequestMonitoringService.js';
-export { LoggingService, LoggingServiceConfig } from './LoggingService.js';
-export { FeedbackService, FeedbackServiceConfig } from './FeedbackService.js';
+export { LoggingService, type LoggingServiceConfig } from './LoggingService.js';
+export { FeedbackService, type FeedbackServiceConfig } from './FeedbackService.js';

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * Run `npm run sync-version` or `npm run build` to regenerate.
  */
 
-export const PACKAGE_VERSION = '0.3.1';
+export const PACKAGE_VERSION = '0.4.0';
 export const PACKAGE_NAME = 'coolhand-node';
 
 /**

--- a/test/base-url.test.ts
+++ b/test/base-url.test.ts
@@ -2,6 +2,7 @@ import { Coolhand } from '../src/index';
 import { LoggingService } from '../src/services/LoggingService';
 import { FeedbackService } from '../src/services/FeedbackService';
 import { CoolhandCallData } from '../src/types';
+import { _resetGlobalState } from '../src/global-monitor';
 
 const fakeCallData: CoolhandCallData = {
   id: 1,
@@ -197,6 +198,7 @@ describe('baseUrl configuration', () => {
     const envBackup: Record<string, string | undefined> = {};
 
     beforeEach(() => {
+      _resetGlobalState();
       jest.resetModules();
       jest.spyOn(console, 'log').mockImplementation();
       jest.spyOn(console, 'warn').mockImplementation();

--- a/test/esm-patching.test.ts
+++ b/test/esm-patching.test.ts
@@ -10,6 +10,7 @@
 
 import { PatternMatchingService } from '../src/services/PatternMatchingService';
 import { LoggingService } from '../src/services/LoggingService';
+import { _resetGlobalState } from '../src/global-monitor';
 
 jest.mock('fs');
 jest.mock('../src/services/PatternMatchingService');
@@ -61,6 +62,7 @@ describe('ESM namespace detection and createRequire fallback', () => {
   });
 
   beforeEach(() => {
+    _resetGlobalState();
     jest.resetModules();
     jest.clearAllMocks();
 
@@ -279,6 +281,7 @@ describe('Edge runtime bypass is preserved', () => {
   let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    _resetGlobalState();
     jest.resetModules();
     jest.clearAllMocks();
     consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
@@ -330,6 +333,7 @@ describe('Edge runtime bypass is preserved', () => {
 
 describe('All four HTTP methods are patched when configurable', () => {
   beforeEach(() => {
+    _resetGlobalState();
     jest.resetModules();
     jest.clearAllMocks();
     jest.spyOn(console, 'log').mockImplementation();

--- a/test/integration-config.test.ts
+++ b/test/integration-config.test.ts
@@ -6,7 +6,7 @@
  * modified PatternMatchingService and global-monitor code paths.
  */
 
-// No top-level fs/path imports needed — mocking is done within jest.isolateModules
+import { _resetGlobalState } from '../src/global-monitor';
 
 // ---------------------------------------------------------------------------
 // 1. Coolhand class: all configuration options
@@ -256,6 +256,7 @@ describe('Global monitoring configuration', () => {
   });
 
   beforeEach(() => {
+    _resetGlobalState();
     jest.restoreAllMocks();
     jest.resetModules();
 
@@ -332,6 +333,7 @@ describe('Auto-monitor environment variable configuration', () => {
   const envBackup: Record<string, string | undefined> = {};
 
   beforeEach(() => {
+    _resetGlobalState();
     jest.restoreAllMocks();
     jest.resetModules();
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,13 +1,15 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: {
-    index: 'src/index.ts',
-    'auto-monitor': 'src/auto-monitor.ts',
-  },
+  // Compile every source file individually rather than bundling entry points.
+  // Bundling duplicates global-monitor into both index and auto-monitor, breaking
+  // the singleton: require('coolhand-node/auto-monitor') initialises one copy while
+  // getGlobalStats() from require('coolhand-node') reads a different uninitialised copy.
+  // With bundle:false, Node's module cache keeps a single shared instance.
+  entry: ['src/**/*.ts'],
+  bundle: false,
   format: ['esm', 'cjs'],
   dts: true,
-  splitting: false,
   sourcemap: true,
   clean: true,
   target: 'es2020',

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    'auto-monitor': 'src/auto-monitor.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  target: 'es2020',
+  outDir: 'dist',
+});


### PR DESCRIPTION
## What's new

- **CJS build**: `dist/index.cjs` and `dist/auto-monitor.cjs` are now published alongside the existing ESM outputs. The exports map includes `"require"` conditions for both entry points.
- CommonJS projects can now use `require('coolhand-node')` and `require('coolhand-node/auto-monitor')` directly — no dynamic `import()` or `new Function` workaround needed.
- TypeScript projects compiled with `"module": "commonjs"` work out of the box.

## What changed

- Build tool switched from `tsc` to `tsup` (esbuild-based); a `tsup.config.ts` config file is added.
- `PatternMatchingService.loadAPIPatternsSync` path resolution updated: the bundled output lands at `dist/index.cjs` so `__dirname` is `dist/` directly. Now tries `dist/api-patterns.json` first, with `../` as fallback for tsc/Jest source environments.
- README Module System Compatibility section rewritten to reflect native CJS support.
- `scripts/verify-cjs.cjs` smoke test added (run via `npm run test:cjs`); asserts pattern count > 0 and OpenAI domain matching to catch path/bundling regressions before publish.

## Breaking changes

None. ESM consumers are unaffected; the new `.cjs` outputs are additive.

Closes #23