### PR TITLE
docs: add npm version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Coolhand Node.js Monitor
 
+[![npm version](https://badge.fury.io/js/coolhand.svg)](https://badge.fury.io/js/coolhand)
+
 Monitor and log LLM API calls from multiple providers (OpenAI, Anthropic, Google AI, GitHub Models, and more) to the Coolhand analytics platform.
 
 ## Related Packages


### PR DESCRIPTION
## What's New

- Added npm version badge to the top of `README.md`, linking to the `coolhand` package on npm via badge.fury.io.

No API changes, no breaking changes.