### PR TITLE
Fix startup pattern count logging

### DIFF
--- a/src/coolhand.ts
+++ b/src/coolhand.ts
@@ -60,7 +60,7 @@ export class Coolhand {
         console.log('🔬 DEBUG MODE: Verbose logging enabled');
       }
       console.log(`🎯 API Endpoint: ${this.loggingService.getApiEndpoint()}`);
-      console.log(`📋 Loaded ${this.patternMatchingService.getPatternsCount()} API patterns`);
+      console.log(`📋 Loaded ${this.patternMatchingService.getPatternsCountSync()} API patterns`);
     }
 
     this.requestMonitoringService.setupMonitoring();

--- a/test/debug-mode.test.ts
+++ b/test/debug-mode.test.ts
@@ -7,6 +7,7 @@ jest.mock('../src/services/PatternMatchingService.js', () => {
   return {
     PatternMatchingService: jest.fn().mockImplementation(() => ({
       getPatternsCount: jest.fn().mockReturnValue(5),
+      getPatternsCountSync: jest.fn().mockReturnValue(5),
       sanitizeHeaders: jest.fn().mockReturnValue({}),
     }))
   };


### PR DESCRIPTION
What changed: Coolhand startup logging now uses the synchronous pattern count accessor so non-silent initialization prints the loaded pattern count instead of a Promise-like value.
What is new: The debug-mode PatternMatchingService mock now includes getPatternsCountSync to cover this constructor path.
Breaking changes: None.
Validation: npm run lint, npm run typecheck, and npm test all pass.