### PR TITLE
[Closes #50] build: wire CJS+ESM smoke tests into prepublishOnly gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "sync-version": "node scripts/sync-version.mjs",
     "build": "npm run sync-version && tsup && node scripts/fix-cjs-imports.cjs && cp src/api-patterns.json dist/",
-    "prepublishOnly": "npm run typecheck && npm run build",
+    "prepublishOnly": "npm run typecheck && npm run build && npm run test:cjs && npm run test:esm",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
## What's new

`npm publish` now runs `test:cjs` and `test:esm` as part of the `prepublishOnly` gate. Previously these smoke tests existed but were manual-only.

## What changed

- `prepublishOnly` in `package.json`: appended `&& npm run test:cjs && npm run test:esm` after the build step.

## Why

The singleton-across-formats invariant (`bundle: true`, `global-monitor` shared state) is easy to silently break when touching `tsup.config.ts`, `scripts/fix-cjs-imports.cjs`, or the exports map. The smoke tests catch exactly this class of regression — but only if they actually run at publish time.

## Breaking changes

None. The smoke tests already ran against `dist/` and pass cleanly; publish time increases by under a second.