### PR TITLE
docs: document environment removal + backward-compat shim (fixes #46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] - 2026-05-11
 
+### 💥 Breaking Changes
+- **`environment` option removed** — The `environment: 'local' | 'production'` field has been removed from `CoolhandOptions` and `GlobalMonitorConfig`. Replace `environment: 'local'` with `baseUrl: 'http://localhost:3000'`, and remove `environment: 'production'` (the default URL is unchanged).
+
 ### ✨ New Features
 - **`baseUrl` option** — Both `new Coolhand({ baseUrl })` and `initializeGlobalMonitoring({ baseUrl })` now accept an optional `baseUrl` to redirect log and feedback POSTs to a self-hosted endpoint. When omitted, behavior is unchanged (default: `https://coolhandlabs.com`).
 - **`COOLHAND_BASE_URL` environment variable** — Auto-monitor reads this variable and forwards it to `initializeGlobalMonitoring`, enabling zero-code-change self-hosted setups.

--- a/README.md
+++ b/README.md
@@ -364,6 +364,22 @@ await initializeGlobalMonitoring({
 });
 ```
 
+### Migrating from v0.3.x to v0.4.0
+
+The `environment` option has been removed. Use `baseUrl` instead:
+
+```ts
+// before (≤0.3.x)
+new Coolhand({ apiKey, environment: 'local' });
+initializeGlobalMonitoring({ apiKey, environment: 'local' });
+
+// after (≥0.4.0)
+new Coolhand({ apiKey, baseUrl: 'http://localhost:3000' });
+initializeGlobalMonitoring({ apiKey, baseUrl: 'http://localhost:3000' });
+```
+
+`environment: 'production'` can simply be removed — the default endpoint (`https://coolhandlabs.com`) is unchanged.
+
 ### Migrating from v0.4.x
 
 Prior to v0.5.0, `debug: true` suppressed all API submissions. This behavior has been renamed to `dryRun: true`. If you previously used `debug: true` to prevent data from being sent, replace it with `dryRun: true`. Passing `debug: true` without `dryRun: true` will emit a `console.warn` deprecation notice.

--- a/src/coolhand.ts
+++ b/src/coolhand.ts
@@ -22,6 +22,17 @@ export class Coolhand {
       throw new Error('API key is required');
     }
 
+    if (options.environment !== undefined) {
+      console.warn(
+        '[coolhand-node] DEPRECATION WARNING: The `environment` option was removed in v0.4.0. ' +
+        "Use `baseUrl: 'http://localhost:3000'` instead of `environment: 'local'`. " +
+        'Remove `environment: \'production\'` — the default endpoint is unchanged.'
+      );
+      if (options.environment === 'local' && options.baseUrl === undefined) {
+        options = { ...options, baseUrl: 'http://localhost:3000' };
+      }
+    }
+
     // Initialize services
     this.patternMatchingService = new PatternMatchingService({ customPatternsFile: options.patternsFile, silent: this.silent });
 

--- a/src/coolhand.ts
+++ b/src/coolhand.ts
@@ -22,6 +22,7 @@ export class Coolhand {
       throw new Error('API key is required');
     }
 
+    // TODO: remove after v1.x.x — backward-compat shim for deprecated `environment` option
     if (options.environment !== undefined) {
       console.warn(
         '[coolhand-node] DEPRECATION WARNING: The `environment` option was removed in v0.4.0. ' +

--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -102,6 +102,7 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
 
   let resolvedBaseUrl = config.baseUrl;
 
+  // TODO: remove after v1.x.x — backward-compat shim for deprecated `environment` option
   if (config.environment !== undefined) {
     console.warn(
       '[coolhand-node] DEPRECATION WARNING: The `environment` option was removed in v0.4.0. ' +

--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -84,6 +84,8 @@ interface GlobalMonitorConfig {
   debug?: boolean;
   dryRun?: boolean;
   baseUrl?: string;
+  /** @deprecated Use `baseUrl` instead. Removed in v0.4.0; this shim will be removed in a future release. */
+  environment?: 'local' | 'production';
 }
 
 /**
@@ -97,6 +99,19 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
   }
 
   silent = config.silent !== false;
+
+  let resolvedBaseUrl = config.baseUrl;
+
+  if (config.environment !== undefined) {
+    console.warn(
+      '[coolhand-node] DEPRECATION WARNING: The `environment` option was removed in v0.4.0. ' +
+      "Use `baseUrl: 'http://localhost:3000'` instead of `environment: 'local'`. " +
+      'Remove `environment: \'production\'` — the default endpoint is unchanged.'
+    );
+    if (config.environment === 'local' && resolvedBaseUrl === undefined) {
+      resolvedBaseUrl = 'http://localhost:3000';
+    }
+  }
 
   if (config.debug && !config.dryRun) {
     console.warn(
@@ -113,7 +128,7 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
     silent,
     debug: config.debug,
     dryRun: config.dryRun,
-    baseUrl: config.baseUrl
+    baseUrl: resolvedBaseUrl
   });
 
   // Load Node.js modules if available

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,8 @@ export interface CoolhandOptions {
   dryRun?: boolean;
   baseUrl?: string;
   excludeApiPatterns?: string[];
+  /** @deprecated Use `baseUrl` instead. Removed in v0.4.0; this shim will be removed in a future release. */
+  environment?: 'local' | 'production';
 }
 
 export interface CoolhandCallData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface CoolhandOptions {
   dryRun?: boolean;
   baseUrl?: string;
   excludeApiPatterns?: string[];
-  /** @deprecated Use `baseUrl` instead. Removed in v0.4.0; this shim will be removed in a future release. */
+  /** @deprecated Use `baseUrl` instead. Removed in v0.4.0; shim will be removed after v1.x.x. */
   environment?: 'local' | 'production';
 }
 


### PR DESCRIPTION
## What's new

- **README** — new "Migrating from v0.3.x to v0.4.0" section showing the `environment` → `baseUrl` replacement, placed alongside the existing v0.4.x → v0.5.0 migration note.
- **CHANGELOG [0.4.0]** — adds a missing `💥 Breaking Changes` entry for the `environment` field removal (the entry previously only documented the *addition* of `baseUrl`).

## What changed

- `CoolhandOptions` and `GlobalMonitorConfig` re-accept `environment?: 'local' | 'production'` marked `@deprecated`, so existing 0.3.x code compiles without TS2353.
- Both the `Coolhand` constructor and `initializeGlobalMonitoring` now emit a `console.warn` deprecation notice when `environment` is passed, and map `'local'` → `baseUrl: 'http://localhost:3000'` automatically. The caller's config object is never mutated (`resolvedBaseUrl` local variable).

## Breaking changes

None in this PR. The `environment` shim is additive; the field will be removed in a future release.