### PR TITLE
fix: correct fetch(Request) interception in global monitor

### DIFF
--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -206,6 +206,70 @@ function unregisterActiveRequest(requestId: string, uniqueId: string): void {
   }
 }
 
+function isIdempotentMethod(method: string): boolean {
+  const normalized = method.toUpperCase();
+  return normalized === 'GET' || normalized === 'HEAD';
+}
+
+function isRequestLike(value: unknown): value is Request {
+  if (!value || typeof value !== 'object') { return false; }
+  const request = value as Partial<Request>;
+  return typeof request.url === 'string' && typeof request.method === 'string';
+}
+
+function headersToRecord(headers: any): Record<string, any> {
+  if (!headers) { return {}; }
+
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+
+  if (typeof headers.entries === 'function') {
+    return Object.fromEntries(headers.entries());
+  }
+
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+
+  return { ...headers };
+}
+
+function getFetchURL(url: string | URL | Request): string {
+  if (typeof url === 'string') { return url; }
+  if (isRequestLike(url)) { return url.url; }
+  return url.toString();
+}
+
+function getFetchMethod(url: string | URL | Request, options: RequestInit): string {
+  return options.method || (isRequestLike(url) ? url.method : 'GET');
+}
+
+function getFetchHeaders(url: string | URL | Request, options: RequestInit): Record<string, any> {
+  // init.headers replaces request headers entirely per the fetch spec —
+  // merging would log headers the caller intentionally dropped.
+  if (options.headers !== undefined) {
+    return headersToRecord(options.headers);
+  }
+  return isRequestLike(url) ? headersToRecord(url.headers) : {};
+}
+
+async function getFetchRequestBody(url: string | URL | Request, options: RequestInit): Promise<string | null> {
+  if (options.body !== undefined) {
+    return options.body !== null ? options.body.toString() : null;
+  }
+
+  if (isRequestLike(url) && typeof url.clone === 'function') {
+    try {
+      return await url.clone().text();
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
 function patchHTTPS(): void {
   const originalRequest = https.request;
   const originalGet = https.get;
@@ -227,7 +291,7 @@ function patchHTTPS(): void {
             const method = typeof options === 'object' && 'method' in options ? options.method || 'GET' : 'GET';
             const requestId = generateRequestId(options, `https-${method}`);
 
-            if (isRequestActive(requestId)) {
+            if (isIdempotentMethod(method) && isRequestActive(requestId)) {
               log(`🔄 Skipping duplicate HTTPS request: ${method} ${buildURL(options, 'https')}`);
               return originalRequest.call(this, options as any, callback as any);
             }
@@ -307,7 +371,7 @@ function patchHTTP(): void {
             const method = typeof options === 'object' && 'method' in options ? options.method || 'GET' : 'GET';
             const requestId = generateRequestId(options, `http-${method}`);
 
-            if (isRequestActive(requestId)) {
+            if (isIdempotentMethod(method) && isRequestActive(requestId)) {
               log(`🔄 Skipping duplicate HTTP request: ${method} ${buildURL(options, 'http')}`);
               return originalRequest.call(this, options as any, callback as any);
             }
@@ -371,7 +435,7 @@ function patchFetch(): void {
     const originalFetch = globalThis.fetch;
 
     globalThis.fetch = async function(url: string | URL | Request, options: RequestInit = {}) {
-      const urlStr = typeof url === 'string' ? url : url.toString();
+      const urlStr = getFetchURL(url);
       debugRequest('FETCH', { url: urlStr, ...options });
 
       if (!globalPatternService) {
@@ -381,10 +445,10 @@ function patchFetch(): void {
       const matchedPattern = globalPatternService.matchesAPIPatternFromURL(urlStr);
 
       if (matchedPattern) {
-        const method = options.method || 'GET';
+        const method = getFetchMethod(url, options);
         const requestId = generateRequestId({ url: urlStr }, `fetch-${method}`);
 
-        if (isRequestActive(requestId)) {
+        if (isIdempotentMethod(method) && isRequestActive(requestId)) {
           log(`🔄 Skipping duplicate FETCH: ${method} ${urlStr}`);
           return originalFetch.call(this, url, options);
         }
@@ -503,8 +567,8 @@ async function interceptFetch(
 ): Promise<Response> {
   interceptedCalls++;
 
-  const method = options.method || 'GET';
-  const urlStr = url.toString();
+  const method = getFetchMethod(url, options);
+  const urlStr = getFetchURL(url);
   const requestId = generateRequestId({ url: urlStr }, `fetch-${method}`);
   const uniqueId = registerActiveRequest(requestId);
 
@@ -512,14 +576,12 @@ async function interceptFetch(
     id: interceptedCalls,
     timestamp: new Date().toISOString(),
     method: method,
-    url: urlStr,
+    url: globalPatternService?.sanitizeURL(urlStr) ?? urlStr,
     headers: globalPatternService?.sanitizeHeaders(
-      options.headers instanceof Headers
-        ? Object.fromEntries(options.headers.entries())
-        : (options.headers || {}),
+      getFetchHeaders(url, options),
       matchedPattern?.pattern
     ) || {},
-    request_body: options.body ? parseBody(options.body as string) : null,
+    request_body: null,
     response_body: null,
     response_headers: null,
     status_code: null,
@@ -529,8 +591,16 @@ async function interceptFetch(
   log(`📞 Starting FETCH call #${callData.id} to ${url}`);
 
   try {
-    const response = await originalFetch.call(globalThis, url, options);
+    // Body capture and the outbound request run concurrently. Using Promise.all
+    // keeps the fetch rejection inside this try/catch from the moment it is
+    // created, closing the unhandledRejection window that would exist if
+    // fetchPromise were started outside the guarded block.
+    const [requestBody, response] = await Promise.all([
+      getFetchRequestBody(url, options),
+      originalFetch.call(globalThis, url, options)
+    ]);
 
+    callData.request_body = parseBody(requestBody);
     callData.status_code = response.status;
     callData.response_headers = Object.fromEntries(response.headers.entries());
 
@@ -544,7 +614,6 @@ async function interceptFetch(
       globalLoggingService.logRequestToAPI(callData, matchedPattern, 'global-monitoring');
     }
 
-    // Cleanup
     unregisterActiveRequest(requestId, uniqueId);
 
     return response;

--- a/test/global-monitor.test.ts
+++ b/test/global-monitor.test.ts
@@ -10,6 +10,7 @@ jest.mock('../src/services/LoggingService');
 
 describe('Global Monitor', () => {
   let originalFetch: typeof globalThis.fetch;
+  let underlyingFetchMock: jest.Mock;
   let mockPatternMatchingService: jest.Mocked<PatternMatchingService>;
   let mockLoggingService: jest.Mocked<LoggingService>;
   let globalMonitor: any;
@@ -29,6 +30,7 @@ describe('Global Monitor', () => {
       matchesAPIPatternSync: jest.fn(),
       matchesAPIPatternFromURL: jest.fn(),
       sanitizeHeaders: jest.fn(),
+      sanitizeURL: jest.fn(),
       getLoadedPatterns: jest.fn(),
       getLoadedPatternsSync: jest.fn(),
       getPatternsCount: jest.fn().mockResolvedValue(5),
@@ -44,8 +46,9 @@ describe('Global Monitor', () => {
     (PatternMatchingService as jest.MockedClass<typeof PatternMatchingService>).mockImplementation(() => mockPatternMatchingService);
     (LoggingService as jest.MockedClass<typeof LoggingService>).mockImplementation(() => mockLoggingService);
 
-    // Mock sanitizeHeaders to return headers as-is
+    // Mock sanitizeHeaders and sanitizeURL to pass through as-is
     mockPatternMatchingService.sanitizeHeaders.mockImplementation((headers) => ({ ...headers }));
+    mockPatternMatchingService.sanitizeURL.mockImplementation((url: string) => url);
 
     // Mock Object property descriptors for patching
     jest.spyOn(Object, 'getOwnPropertyDescriptor').mockReturnValue({
@@ -68,6 +71,9 @@ describe('Global Monitor', () => {
         text: () => Promise.resolve('{"result": "success"}')
       })
     });
+
+    // Capture reference before patching so tests can spy on originalFetch calls
+    underlyingFetchMock = globalThis.fetch as jest.Mock;
 
     // Import the module after all mocks are set up
     globalMonitor = await import('../src/global-monitor');
@@ -371,6 +377,194 @@ describe('Global Monitor', () => {
 
       // Verify the configuration was accepted
       expect(config.patternsFile).toBe('./custom-patterns.json');
+    });
+  });
+
+  describe('Deduplication', () => {
+    const mockPattern = {
+      pattern: { name: 'OpenAI', domains: ['api.openai.com'] },
+      matchType: 'domain' as const,
+      matchValue: 'api.openai.com'
+    };
+
+    beforeEach(async () => {
+      await globalMonitor.initializeGlobalMonitoring({ apiKey: 'test-key', silent: true });
+      mockPatternMatchingService.matchesAPIPatternFromURL.mockReturnValue(mockPattern);
+      mockPatternMatchingService.sanitizeHeaders.mockImplementation((headers: any) => ({ ...headers }));
+    });
+
+    it('should intercept all concurrent POST requests to the same URL', async () => {
+      await Promise.all([
+        globalThis.fetch('https://api.openai.com/v1/chat/completions', { method: 'POST', body: '{"prompt":"a"}' }),
+        globalThis.fetch('https://api.openai.com/v1/chat/completions', { method: 'POST', body: '{"prompt":"b"}' }),
+        globalThis.fetch('https://api.openai.com/v1/chat/completions', { method: 'POST', body: '{"prompt":"c"}' }),
+      ]);
+
+      expect(mockLoggingService.logRequestToAPI).toHaveBeenCalledTimes(3);
+    });
+
+    it('should deduplicate concurrent GET requests to the same URL', async () => {
+      await Promise.all([
+        globalThis.fetch('https://api.openai.com/v1/models'),
+        globalThis.fetch('https://api.openai.com/v1/models'),
+      ]);
+
+      expect(mockLoggingService.logRequestToAPI).toHaveBeenCalledTimes(1);
+    });
+
+    it('should intercept all concurrent PUT requests to the same URL', async () => {
+      await Promise.all([
+        globalThis.fetch('https://api.openai.com/v1/thread', { method: 'PUT', body: '{"a":1}' }),
+        globalThis.fetch('https://api.openai.com/v1/thread', { method: 'PUT', body: '{"b":2}' }),
+      ]);
+
+      expect(mockLoggingService.logRequestToAPI).toHaveBeenCalledTimes(2);
+    });
+
+    it('should intercept all concurrent POST calls when url is a Request object', async () => {
+      const url = 'https://api.openai.com/v1/chat/completions';
+      await Promise.all([
+        globalThis.fetch(new Request(url, { method: 'POST', body: '{"prompt":"a"}' })),
+        globalThis.fetch(new Request(url, { method: 'POST', body: '{"prompt":"b"}' })),
+      ]);
+
+      expect(mockLoggingService.logRequestToAPI).toHaveBeenCalledTimes(2);
+    });
+
+    it('should log Request object URL, method, headers, and body', async () => {
+      const url = 'https://api.openai.com/v1/chat/completions';
+
+      await globalThis.fetch(new Request(url, {
+        method: 'POST',
+        headers: { authorization: 'Bearer token' },
+        body: '{"prompt":"a"}'
+      }));
+
+      expect(mockPatternMatchingService.matchesAPIPatternFromURL).toHaveBeenCalledWith(url);
+      expect(mockLoggingService.logRequestToAPI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'POST',
+          url,
+          headers: expect.objectContaining({ authorization: 'Bearer token' }),
+          request_body: { prompt: 'a' }
+        }),
+        mockPattern,
+        'global-monitoring'
+      );
+    });
+
+    it('logs only init headers when fetch(Request, { headers }) is called', async () => {
+      const request = new Request('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'x-stale': 'drop-me', authorization: 'Bearer old' },
+        body: '{}'
+      });
+
+      await globalThis.fetch(request, { headers: { authorization: 'Bearer new' } });
+
+      const [callData] = (mockLoggingService.logRequestToAPI as jest.Mock).mock.calls[0];
+      expect(callData.headers).toMatchObject({ authorization: 'Bearer new' });
+      expect(callData.headers).not.toHaveProperty('x-stale');
+    });
+
+    it('falls back to Request headers when no init.headers is provided', async () => {
+      const request = new Request('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'x-custom': 'keep-me' },
+        body: '{}'
+      });
+
+      await globalThis.fetch(request);
+
+      const [callData] = (mockLoggingService.logRequestToAPI as jest.Mock).mock.calls[0];
+      expect(callData.headers).toHaveProperty('x-custom', 'keep-me');
+    });
+
+    it('sanitizes query-param secrets from the logged URL', async () => {
+      const rawUrl = 'https://api.openai.com/v1/chat/completions?key=secret123';
+      const cleanUrl = 'https://api.openai.com/v1/chat/completions?key=REDACTED';
+      mockPatternMatchingService.sanitizeURL.mockReturnValueOnce(cleanUrl);
+
+      await globalThis.fetch(rawUrl, { method: 'POST', body: '{}' });
+
+      expect(mockPatternMatchingService.sanitizeURL).toHaveBeenCalledWith(rawUrl);
+      const [callData] = (mockLoggingService.logRequestToAPI as jest.Mock).mock.calls[0];
+      expect(callData.url).toBe(cleanUrl);
+    });
+
+    it('logs the empty init body when fetch(Request, { body: "" }) is called, not the original Request body', async () => {
+      const request = new Request('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        body: '{"original":"body"}',
+      });
+
+      await globalThis.fetch(request, { body: '' });
+
+      const [callData] = (mockLoggingService.logRequestToAPI as jest.Mock).mock.calls[0];
+      expect(callData.request_body).toBeNull();
+    });
+
+    it('propagates a fetch rejection that occurs while body capture is still pending', async () => {
+      const fetchError = new Error('network failure');
+      underlyingFetchMock.mockRejectedValueOnce(fetchError);
+
+      const slowReq = {
+        url: 'https://api.openai.com/v1/chat/completions',
+        method: 'POST',
+        headers: new Headers(),
+        clone: jest.fn().mockReturnValue({
+          text: jest.fn().mockImplementation(async () => {
+            await Promise.resolve(); // yield so the fetch rejection fires first
+            return '{"prompt":"test"}';
+          })
+        })
+      };
+
+      await expect(globalThis.fetch(slowReq as any)).rejects.toThrow('network failure');
+      expect(mockLoggingService.logRequestToAPI).not.toHaveBeenCalled();
+    });
+
+    it('fires originalFetch before awaiting a slow Request body', async () => {
+      const events: string[] = [];
+
+      underlyingFetchMock.mockImplementationOnce(async () => {
+        events.push('fetch-called');
+        return {
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          clone: () => ({ text: () => Promise.resolve('{}') })
+        };
+      });
+
+      const slowReq = {
+        url: 'https://api.openai.com/v1/chat/completions',
+        method: 'POST',
+        headers: new Headers(),
+        clone: jest.fn().mockReturnValue({
+          text: jest.fn().mockImplementation(async () => {
+            await Promise.resolve(); // one microtask — yields after getFetchRequestBody suspends
+            events.push('body-resolved');
+            return '{"prompt":"slow"}';
+          })
+        })
+      };
+
+      await globalThis.fetch(slowReq as any);
+
+      expect(events).toEqual(['fetch-called', 'body-resolved']);
+    });
+
+    it('should handle fetch calls when Request is not globally defined', async () => {
+      const originalRequest = (globalThis as any).Request;
+      delete (globalThis as any).Request;
+
+      try {
+        await globalThis.fetch('https://api.openai.com/v1/models');
+      } finally {
+        (globalThis as any).Request = originalRequest;
+      }
+
+      expect(mockLoggingService.logRequestToAPI).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## What's new

- Dedup is now restricted to idempotent methods (GET, HEAD). Previously any two same-URL POSTs within the 1 s window collapsed to one logged call, silently under-reporting parallel LLM fan-out (closes #47).
- `fetch(new Request(url, { method: 'POST' }))` is now intercepted correctly. The method is read from the `Request` object when `options.method` is absent; before this fix it defaulted to `GET` and was treated as idempotent.

## What changed

- `getFetchHeaders` follows the fetch spec: `init.headers` replaces the `Request` headers entirely rather than merging, so headers the caller intentionally dropped are no longer logged.
- `getFetchRequestBody` checks `options.body !== undefined` instead of truthiness, so `fetch(req, { body: '' })` logs the empty init body rather than falling through to `url.clone().text()` and leaking the original request body.
- `interceptFetch` now uses `Promise.all([getFetchRequestBody(...), originalFetch(...)])` inside the `try/catch`. This keeps the outbound request from being blocked by body capture, and closes the `unhandledRejection` window that existed when `fetchPromise` was started outside the guarded block.
- `callData.url` now passes through `globalPatternService.sanitizeURL`, matching the existing behaviour in `RequestMonitoringService` and preventing query-param secrets (e.g. Gemini `?key=…`) from reaching logs.

## Breaking changes

None. Dedup behaviour changes only affect POST/PUT/PATCH/DELETE — requests that should never have been deduplicated.