### PR TITLE
fix: remove stale pattern count from constructor startup log

### DIFF
--- a/src/coolhand.ts
+++ b/src/coolhand.ts
@@ -72,7 +72,6 @@ export class Coolhand {
         console.log('🔬 DEBUG MODE: Verbose logging enabled');
       }
       console.log(`🎯 API Endpoint: ${this.loggingService.getApiEndpoint()}`);
-      console.log(`📋 Loaded ${this.patternMatchingService.getPatternsCountSync()} API patterns`);
     }
 
     this.requestMonitoringService.setupMonitoring();


### PR DESCRIPTION
## What changed
Removed the `📋 Loaded N API patterns` log line from the `Coolhand` constructor (`src/coolhand.ts`).

## Why
In ESM environments `getPatternsCountSync()` returns `0` at constructor time because pattern loading is async — producing the misleading `📋 Loaded 0 API patterns` message even though patterns load correctly before any real requests fire. `PatternMatchingService` already emits accurate pattern-count logs from every code path (CJS, ESM, Edge, fallback), so the constructor line was redundant.

## Breaking changes
None. The startup log output changes slightly: the pattern count line no longer appears in the `Coolhand` constructor block; counts are still printed by `PatternMatchingService` during initialization.

Fixes #55.