### PR TITLE
fix: branch environment deprecation warning on actual value passed

### DIFF
--- a/src/coolhand.ts
+++ b/src/coolhand.ts
@@ -23,15 +23,19 @@ export class Coolhand {
     }
 
     // TODO: remove after v1.x.x — backward-compat shim for deprecated `environment` option
-    if (options.environment !== undefined) {
+    if (options.environment === 'local') {
       console.warn(
-        '[coolhand-node] DEPRECATION WARNING: The `environment` option was removed in v0.4.0. ' +
-        "Use `baseUrl: 'http://localhost:3000'` instead of `environment: 'local'`. " +
-        'Remove `environment: \'production\'` — the default endpoint is unchanged.'
+        "[coolhand-node] DEPRECATION WARNING: The `environment` option was removed in v0.4.0. " +
+        "Use `baseUrl: 'http://localhost:3000'` instead of `environment: 'local'`."
       );
-      if (options.environment === 'local' && options.baseUrl === undefined) {
+      if (options.baseUrl === undefined) {
         options = { ...options, baseUrl: 'http://localhost:3000' };
       }
+    } else if (options.environment === 'production') {
+      console.warn(
+        "[coolhand-node] DEPRECATION WARNING: The `environment` option was removed in v0.4.0. " +
+        "Remove `environment: 'production'` — the default endpoint is unchanged."
+      );
     }
 
     // Initialize services

--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -129,15 +129,19 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
   let resolvedBaseUrl = config.baseUrl;
 
   // TODO: remove after v1.x.x — backward-compat shim for deprecated `environment` option
-  if (config.environment !== undefined) {
+  if (config.environment === 'local') {
     console.warn(
-      '[coolhand-node] DEPRECATION WARNING: The `environment` option was removed in v0.4.0. ' +
-      "Use `baseUrl: 'http://localhost:3000'` instead of `environment: 'local'`. " +
-      'Remove `environment: \'production\'` — the default endpoint is unchanged.'
+      "[coolhand-node] DEPRECATION WARNING: The `environment` option was removed in v0.4.0. " +
+      "Use `baseUrl: 'http://localhost:3000'` instead of `environment: 'local'`."
     );
-    if (config.environment === 'local' && resolvedBaseUrl === undefined) {
+    if (resolvedBaseUrl === undefined) {
       resolvedBaseUrl = 'http://localhost:3000';
     }
+  } else if (config.environment === 'production') {
+    console.warn(
+      "[coolhand-node] DEPRECATION WARNING: The `environment` option was removed in v0.4.0. " +
+      "Remove `environment: 'production'` — the default endpoint is unchanged."
+    );
   }
 
   if (config.debug && !config.dryRun) {

--- a/test/base-url.test.ts
+++ b/test/base-url.test.ts
@@ -2,7 +2,7 @@ import { Coolhand } from '../src/index';
 import { LoggingService } from '../src/services/LoggingService';
 import { FeedbackService } from '../src/services/FeedbackService';
 import { CoolhandCallData } from '../src/types';
-import { _resetGlobalState } from '../src/global-monitor';
+import { _resetGlobalState, initializeGlobalMonitoring } from '../src/global-monitor';
 
 const fakeCallData: CoolhandCallData = {
   id: 1,
@@ -122,6 +122,51 @@ describe('baseUrl configuration', () => {
         silent: true,
         baseUrl: 'http://127.0.0.1.evil.com'
       })).toThrow('baseUrl must use https://');
+    });
+  });
+
+  describe('deprecated environment option', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      _resetGlobalState();
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    describe('Coolhand constructor', () => {
+      it("emits only the 'local' sentence when environment: 'local' is passed", () => {
+        new Coolhand({ apiKey: 'test-key', silent: true, environment: 'local' });
+        const msg = warnSpy.mock.calls[0][0] as string;
+        expect(msg).toContain("environment: 'local'");
+        expect(msg).not.toContain("environment: 'production'");
+      });
+
+      it("emits only the 'production' sentence when environment: 'production' is passed", () => {
+        new Coolhand({ apiKey: 'test-key', silent: true, environment: 'production' });
+        const msg = warnSpy.mock.calls[0][0] as string;
+        expect(msg).toContain("environment: 'production'");
+        expect(msg).not.toContain("environment: 'local'");
+      });
+    });
+
+    describe('initializeGlobalMonitoring', () => {
+      it("emits only the 'local' sentence when environment: 'local' is passed", async () => {
+        await initializeGlobalMonitoring({ apiKey: 'test-key', silent: true, environment: 'local' });
+        const msg = warnSpy.mock.calls[0][0] as string;
+        expect(msg).toContain("environment: 'local'");
+        expect(msg).not.toContain("environment: 'production'");
+      });
+
+      it("emits only the 'production' sentence when environment: 'production' is passed", async () => {
+        await initializeGlobalMonitoring({ apiKey: 'test-key', silent: true, environment: 'production' });
+        const msg = warnSpy.mock.calls[0][0] as string;
+        expect(msg).toContain("environment: 'production'");
+        expect(msg).not.toContain("environment: 'local'");
+      });
     });
   });
 


### PR DESCRIPTION
## What's new

The `environment` deprecation warning (introduced as a backward-compat shim in v0.4.0) now emits a message tailored to the value the caller actually passed.

## What changed

- `environment: 'local'` → warns only about migrating to `baseUrl: 'http://localhost:3000'`
- `environment: 'production'` → warns only to remove the option (default endpoint is unchanged)

Previously both sentences fired unconditionally regardless of which value was passed. Fix applied in both `Coolhand` constructor (`src/coolhand.ts`) and `initializeGlobalMonitoring` (`src/global-monitor.ts`).

Four tests added to `test/base-url.test.ts` to pin each branch's output.

## Breaking changes

None — the shim behavior (URL resolution, endpoint routing) is unchanged.

Closes #57