### PR TITLE
[closes #58] fix: suppress duplicate auto-monitor banner on Next.js startup

### DIFF
--- a/src/auto-monitor.ts
+++ b/src/auto-monitor.ts
@@ -37,6 +37,10 @@ if (apiKey) {
   // Async initialization wrapped in IIFE
   (async () => {
     try {
+      if (isGlobalMonitoringActive()) {
+        return;
+      }
+
       if (!silent) {
         console.log('🔧 Auto-initializing global monitoring...');
       }

--- a/test/auto-monitor.test.ts
+++ b/test/auto-monitor.test.ts
@@ -1,0 +1,58 @@
+describe('auto-monitor', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.resetModules();
+  });
+
+  function loadIsolated(isActive: boolean, apiKey?: string): { initMock: jest.Mock; isActiveMock: jest.Mock } {
+    const initMock = jest.fn().mockResolvedValue(undefined);
+    const isActiveMock = jest.fn().mockReturnValue(isActive);
+
+    if (apiKey !== undefined) {
+      process.env.COOLHAND_API_KEY = apiKey;
+    } else {
+      delete process.env.COOLHAND_API_KEY;
+    }
+
+    jest.isolateModules(() => {
+      jest.doMock('../src/global-monitor.js', () => ({
+        isGlobalMonitoringActive: isActiveMock,
+        initializeGlobalMonitoring: initMock,
+        getGlobalStats: jest.fn(),
+      }));
+      require('../src/auto-monitor');
+    });
+
+    return { initMock, isActiveMock };
+  }
+
+  it('skips init silently when singleton is already active (second module context)', async () => {
+    process.env.COOLHAND_SILENT = 'false';
+    const { initMock } = loadIsolated(true, 'test-key');
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(initMock).not.toHaveBeenCalled();
+    expect(console.log).not.toHaveBeenCalledWith('🔧 Auto-initializing global monitoring...');
+  });
+
+  it('initializes when singleton is not yet active (first module context)', async () => {
+    process.env.COOLHAND_SILENT = 'false';
+    const { initMock } = loadIsolated(false, 'test-key');
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(initMock).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'test-key' }));
+  });
+
+  it('does not init when COOLHAND_API_KEY is absent', async () => {
+    const { initMock } = loadIsolated(false, undefined);
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(initMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What's new / changed

**Fixed:** `coolhand-node/auto-monitor` no longer prints its initialization banner twice when imported in a Next.js project. Next.js evaluates `next.config.js` in multiple module contexts (server + edge), causing the module's top-level IIFE to run once per context. The singleton patching was already guarded via `globalThis`, but the banner fired before that check.

**Change:** Added an early-return guard at the top of the IIFE using the already-imported `isGlobalMonitoringActive()`. If the singleton is already active in `globalThis`, the second context silently no-ops — no banner, no duplicate init call.

**Tests:** Added `test/auto-monitor.test.ts` covering the guard (second-context skip), normal first-context initialization, and the no-API-key path.

## Breaking changes

None.