### PR TITLE
chore: prep v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-05-18
+
+### ✨ New Features
+- **GitHub Models support** — `models.github.ai` and `models.inference.ai.azure.com` are now included in the default monitored endpoints out of the box.
+- **`excludeApiPatterns` option** — Pass an array of glob patterns to `new Coolhand({ excludeApiPatterns })` or `initializeGlobalMonitoring({ excludeApiPatterns })` to skip specific endpoints (e.g. operational health-check URLs) from being logged.
+- **`sentiment` field in feedback** — `createFeedback()` now accepts `sentiment: 'like' | 'dislike' | 'neutral'`. The legacy boolean `like` field is deprecated and auto-converted.
+- **CommonJS (`require()`) support** — `coolhand-node` now ships dual CJS + ESM builds. `require('coolhand-node')` and `require('coolhand-node/auto-monitor')` work in any Node.js project without configuration.
+
+### 🐛 Bug Fixes
+- **`fetch(Request)` interception** — `fetch(new Request(url, { method: 'POST', ... }))` is now intercepted correctly. Headers from `init` properly override `Request` headers; request body is read from `init.body` when provided; deduplication is restricted to idempotent methods (GET, HEAD).
+- **Startup pattern count log** — The `📋 Loaded N API patterns` constructor log no longer shows a stale `0` count in ESM environments where patterns load asynchronously.
+- **Duplicate auto-monitor banner** — `coolhand-node/auto-monitor` now prints its initialization banner only once, even when the module is evaluated in multiple contexts (e.g. CJS + ESM interop).
+- **Gzip / deflate decompression** — Response body decompression in the global monitor now handles deflate streams that omit the zlib wrapper (RFC 1951 raw deflate), fixing silent data loss for some providers.
+
+### 🔧 Build & CI
+- CJS + ESM smoke tests are now gated in `prepublishOnly` — a publish will fail if either format is broken.
+- CI runs the full CJS + ESM smoke test matrix on every PR across Node 18, 20, and 22.
+
 ## [0.5.0] - 2026-05-12
 
 ### 💥 Breaking Changes

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ const feedback = await coolhand.createFeedback({
 | `debug` | boolean | `false` | Enable verbose logging (endpoint URL and payload size logged before each call) |
 | `dryRun` | boolean | `false` | Skip all API submissions — no data is sent to Coolhand |
 | `patternsFile` | string | `undefined` | Path to custom API patterns file |
+| `excludeApiPatterns` | string[] | `[]` | Glob patterns for endpoints to exclude from monitoring (e.g. health checks). |
 | `baseUrl` | string | `'https://coolhandlabs.com'` | Override the API host for self-hosted deployments. Must be `https://` (or `http://localhost` for local dev). |
 
 ### Environment Variables
@@ -439,7 +440,7 @@ The monitor handles errors gracefully:
 
 - API keys in request headers are automatically redacted
 - No sensitive data is exposed in logs
-- Debug mode prevents data from being sent to external servers
+- Dry-run mode (`dryRun: true`) prevents any data from being sent to external servers
 
 ## Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coolhand-node",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coolhand-node",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coolhand-node",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Monitor and LLM API calls for analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * Run `npm run sync-version` or `npm run build` to regenerate.
  */
 
-export const PACKAGE_VERSION = '0.5.0';
+export const PACKAGE_VERSION = '0.6.0';
 export const PACKAGE_NAME = 'coolhand-node';
 
 /**


### PR DESCRIPTION
## What's new in v0.6.0

**New features:**
- GitHub Models (`models.github.ai`, `models.inference.ai.azure.com`) added to default monitored endpoints
- `excludeApiPatterns` option — pass glob patterns to skip specific endpoints (e.g. health checks) from being logged
- `sentiment: 'like' | 'dislike' | 'neutral'` field on `createFeedback()`; legacy boolean `like` is deprecated and auto-converted
- Dual CJS + ESM build — `require('coolhand-node')` and `require('coolhand-node/auto-monitor')` now work in any Node.js project without configuration

**Bug fixes:**
- `fetch(new Request(...))` now intercepted correctly; `init` headers/body take precedence and dedup is restricted to idempotent methods (GET, HEAD)
- Startup pattern count no longer logs a stale `0` in ESM environments
- `auto-monitor` initialization banner suppressed on duplicate module evaluation (CJS + ESM interop)
- Deflate responses using raw RFC 1951 encoding (no zlib wrapper) now decompress correctly

**Build & CI:**
- CJS + ESM smoke tests gated in `prepublishOnly`; CI matrix covers Node 18, 20, and 22 on every PR

## What changed

- `CHANGELOG.md` — new `[0.6.0]` entry
- `README.md` — `excludeApiPatterns` added to config table; Security section corrected (`debug` → `dryRun`)
- `package.json` / `package-lock.json` / `src/version.ts` — version bumped `0.5.0` → `0.6.0`

## Breaking changes

None in this PR. Breaking changes from earlier unreleased work are documented in `[0.4.0]` (`environment` option removed) and `[0.5.0]` (`debug` no longer suppresses submissions — use `dryRun`).