### PR TITLE
fix: correct npm badge link to coolhand-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Coolhand Node.js Monitor
 
-[![npm version](https://badge.fury.io/js/coolhand.svg)](https://badge.fury.io/js/coolhand)
+[![npm version](https://badge.fury.io/js/coolhand-node.svg)](https://badge.fury.io/js/coolhand-node)
 
 Monitor and log LLM API calls from multiple providers (OpenAI, Anthropic, Google AI, GitHub Models, and more) to the Coolhand analytics platform.
 


### PR DESCRIPTION
## What's new / changed

- Fixed the npm version badge in the README — it was linking to the `coolhand` package (a different, unrelated package on npm) instead of `coolhand-node`.

## Breaking changes

None.