### PR TITLE
Carry is_from through createFeedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coolhand-node",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coolhand-node",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coolhand-node",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Monitor and LLM API calls for analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,8 @@ export interface LLMRequestLogFeedback {
   /** @deprecated Use `sentiment` instead */
   like?: boolean;
   sentiment?: "like" | "dislike" | "neutral";
+  /** Who supplied the feedback. Defaults to "unknown" server-side when omitted. */
+  is_from?: "human" | "agent" | "unknown";
   creator_unique_id?: string;
   workload_hashid?: string;
   explanation?: string;
@@ -91,6 +93,8 @@ export interface LLMRequestLogFeedbackResponse {
   /** @deprecated Use `sentiment` instead */
   like?: boolean;
   sentiment?: "like" | "dislike" | "neutral";
+  /** Who supplied the feedback: "human", "agent", or "unknown". */
+  is_from?: "human" | "agent" | "unknown";
   creator_unique_id?: string;
   workload_hashid?: string;
   explanation?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,8 +71,8 @@ export interface LLMRequestLogFeedback {
   /** @deprecated Use `sentiment` instead */
   like?: boolean;
   sentiment?: "like" | "dislike" | "neutral";
-  /** Who supplied the feedback. Defaults to "unknown" server-side when omitted. */
-  is_from?: "human" | "agent" | "unknown";
+  /** What kind of creator supplied the feedback. Defaults to "unknown" server-side when omitted. */
+  creator_type?: "human" | "agent" | "unknown";
   creator_unique_id?: string;
   workload_hashid?: string;
   explanation?: string;
@@ -93,8 +93,8 @@ export interface LLMRequestLogFeedbackResponse {
   /** @deprecated Use `sentiment` instead */
   like?: boolean;
   sentiment?: "like" | "dislike" | "neutral";
-  /** Who supplied the feedback: "human", "agent", or "unknown". */
-  is_from?: "human" | "agent" | "unknown";
+  /** What kind of creator submitted the feedback: "human", "agent", or "unknown". */
+  creator_type?: "human" | "agent" | "unknown";
   creator_unique_id?: string;
   workload_hashid?: string;
   explanation?: string;

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * Run `npm run sync-version` or `npm run build` to regenerate.
  */
 
-export const PACKAGE_VERSION = '0.6.0';
+export const PACKAGE_VERSION = '0.7.0';
 export const PACKAGE_NAME = 'coolhand-node';
 
 /**

--- a/test/feedback-service.test.ts
+++ b/test/feedback-service.test.ts
@@ -177,7 +177,7 @@ describe('FeedbackService', () => {
       expect(capturedFeedback.revised_output).toBe('Revised output');
     });
 
-    it('sends is_from when provided', async () => {
+    it('sends creator_type when provided', async () => {
       let capturedRequestBody: any;
 
       (global as any).fetch = jest.fn().mockImplementation(async (input: any, options: any) => {
@@ -195,12 +195,12 @@ describe('FeedbackService', () => {
       const feedback: LLMRequestLogFeedback = {
         llm_request_log_id: 456,
         explanation: 'Capability missing',
-        is_from: 'agent'
+        creator_type: 'agent'
       };
 
       await service.createFeedback(feedback);
 
-      expect(capturedRequestBody.llm_request_log_feedback.is_from).toBe('agent');
+      expect(capturedRequestBody.llm_request_log_feedback.creator_type).toBe('agent');
     });
 
     it('should set correct headers', async () => {

--- a/test/feedback-service.test.ts
+++ b/test/feedback-service.test.ts
@@ -177,6 +177,32 @@ describe('FeedbackService', () => {
       expect(capturedFeedback.revised_output).toBe('Revised output');
     });
 
+    it('sends is_from when provided', async () => {
+      let capturedRequestBody: any;
+
+      (global as any).fetch = jest.fn().mockImplementation(async (input: any, options: any) => {
+        capturedRequestBody = JSON.parse(options.body);
+        return {
+          ok: true,
+          status: 200,
+          json: jest.fn().mockResolvedValue({ id: 123, like: true }),
+          text: jest.fn().mockResolvedValue(JSON.stringify({ id: 123, like: true }))
+        };
+      });
+
+      const service = new FeedbackService({ apiKey: 'test-api-key', silent: true });
+
+      const feedback: LLMRequestLogFeedback = {
+        llm_request_log_id: 456,
+        explanation: 'Capability missing',
+        is_from: 'agent'
+      };
+
+      await service.createFeedback(feedback);
+
+      expect(capturedRequestBody.llm_request_log_feedback.is_from).toBe('agent');
+    });
+
     it('should set correct headers', async () => {
       let capturedHeaders: any;
 


### PR DESCRIPTION
Adds `is_from` to the feedback types so the source rides along when feedback is submitted through the SDK. Part of the cross-repo work behind the coolhand-cli `report-blocker` tool (Coolhand-Labs/coolhand-cli#17).

1. `src/types.ts`: adds optional `is_from?: 'human' | 'agent' | 'unknown'` to `LLMRequestLogFeedback` and `LLMRequestLogFeedbackResponse`. Transport already forwards the whole object, so no other change is needed.
2. `test/feedback-service.test.ts`: confirms `is_from` is sent in the payload.
3. `package.json`: version bump to 0.7.0 so coolhand-cli can depend on it.

Shared public SDK types, so reviewers may want to confirm the field name and values match the Rails API.
