### PR TITLE
feat: add public logRequest() for manual session submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,29 @@ async function startServer() {
 
 See the [framework guides](#framework-integration) for complete examples.
 
+## Manual Submission API
+
+Submit a captured LLM request/response that did not flow through automatic monitoring — for example, a CLI tool replaying locally-saved session turns.
+
+```typescript
+import { Coolhand } from 'coolhand-node';
+
+const coolhand = new Coolhand({
+  apiKey: 'your-api-key'
+});
+
+const result = await coolhand.logRequest(rawRequest, {
+  collector: 'my-cli/1.0.0' // optional: overrides the default SDK collector string
+});
+
+// result is CoolhandLogResponse | null
+// null is returned on submission failure, in dry-run mode, or when using
+// the HTTPS fallback path (Node.js < 18, where the response body is not parsed)
+console.log(result?.id); // Coolhand log ID assigned by the API
+```
+
+`rawRequest` must be a `CoolhandCallData` object — the same shape that automatic monitoring captures internally (fields: `id`, `timestamp`, `method`, `url`, `headers`, `request_body`, `response_body`, `response_headers`, `status_code`, `protocol`).
+
 ## Feedback API
 
 Collect feedback on LLM responses to improve model performance.

--- a/README.md
+++ b/README.md
@@ -168,29 +168,6 @@ async function startServer() {
 
 See the [framework guides](#framework-integration) for complete examples.
 
-## Manual Submission API
-
-Submit a captured LLM request/response that did not flow through automatic monitoring — for example, a CLI tool replaying locally-saved session turns.
-
-```typescript
-import { Coolhand } from 'coolhand-node';
-
-const coolhand = new Coolhand({
-  apiKey: 'your-api-key'
-});
-
-const result = await coolhand.logRequest(rawRequest, {
-  collector: 'my-cli/1.0.0' // optional: overrides the default SDK collector string
-});
-
-// result is CoolhandLogResponse | null
-// null is returned on submission failure, in dry-run mode, or when using
-// the HTTPS fallback path (Node.js < 18, where the response body is not parsed)
-console.log(result?.id); // Coolhand log ID assigned by the API
-```
-
-`rawRequest` must be a `CoolhandCallData` object — the same shape that automatic monitoring captures internally (fields: `id`, `timestamp`, `method`, `url`, `headers`, `request_body`, `response_body`, `response_headers`, `status_code`, `protocol`).
-
 ## Feedback API
 
 Collect feedback on LLM responses to improve model performance.
@@ -470,6 +447,7 @@ The monitor handles errors gracefully:
 - **[Framework Integration Guide](./docs/framework-integration.md)** - Complete setup for all frameworks. (Well, some are more complete than others.)
 - **[Global Monitoring Guide](./docs/global-monitoring.md)** - Advanced global monitoring features. Even easier than asking your favorite LLM coding tool to do it for you.
 - **[React Integration Guide](./docs/frameworks/react.md)** - Frontend integration patterns. We won't ask about how you are planning to keep your API keys secret.
+- **[Manual Submission API](./docs/manual-submission.md)** - Submit captured LLM requests outside of automatic monitoring (e.g. from a CLI tool).
 
 ## Related Packages
 

--- a/docs/manual-submission.md
+++ b/docs/manual-submission.md
@@ -1,0 +1,48 @@
+# Manual Submission API
+
+`logRequest()` lets you submit a captured LLM request/response that did not flow through automatic monitoring — for example, a CLI tool replaying locally-saved session turns.
+
+## Usage
+
+```typescript
+import { Coolhand } from 'coolhand-node';
+
+const coolhand = new Coolhand({
+  apiKey: 'your-api-key'
+});
+
+const result = await coolhand.logRequest(rawRequest, {
+  collector: 'my-cli/1.0.0' // optional: overrides the default SDK collector string
+});
+
+// result is CoolhandLogResponse | null
+// null is returned on submission failure, in dry-run mode, or when using
+// the HTTPS fallback path (Node.js < 18, where the response body is not parsed)
+console.log(result?.id); // Coolhand log ID assigned by the API
+```
+
+## Parameters
+
+**`rawRequest: CoolhandCallData`** — the captured request/response payload. Fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `number` | Local sequence ID for the call |
+| `timestamp` | `string` | ISO 8601 capture time |
+| `method` | `string` | HTTP method (`POST`, `GET`, …) |
+| `url` | `string` | Full request URL |
+| `headers` | `object` | Request headers |
+| `request_body` | `object \| null` | Parsed request body |
+| `response_body` | `object \| null` | Parsed response body |
+| `response_headers` | `object \| null` | Response headers |
+| `status_code` | `number` | HTTP status code |
+| `protocol` | `string` | Protocol identifier (e.g. `claudecode`) |
+
+**`options.collector?: string`** — overrides the default SDK collector string (e.g. `'coolhand-cli/claude-code'`). When omitted, the SDK derives the collector from the package name and version.
+
+## Return value
+
+`Promise<CoolhandLogResponse | null>` — resolves to the API response on success, or `null` when:
+- the submission failed (network error or non-2xx response)
+- `dryRun` mode is enabled
+- the request was sent via the HTTPS fallback (Node.js < 18, where the response body is not parsed)

--- a/src/coolhand.ts
+++ b/src/coolhand.ts
@@ -93,7 +93,9 @@ export class Coolhand {
    * @param rawRequest The captured request/response payload.
    * @param options Optional settings. `collector` identifies the submission source and
    *   overrides the default SDK collector string.
-   * @returns Promise resolving to the created log response, or null if submission failed.
+   * @returns Promise resolving to the created log response, or null if submission failed
+   *   or if the request was sent via the HTTPS fallback (Node.js < 18, where the response
+   *   body is not parsed).
    */
   public async logRequest(
     rawRequest: CoolhandCallData,

--- a/src/coolhand.ts
+++ b/src/coolhand.ts
@@ -1,4 +1,4 @@
-import { CoolhandOptions, CoolhandCallData, CoolhandStats, LLMRequestLogFeedback, LLMRequestLogFeedbackResponse, CoolhandMatchedPattern } from './types.js';
+import { CoolhandOptions, CoolhandCallData, CoolhandLogResponse, CoolhandStats, LLMRequestLogFeedback, LLMRequestLogFeedbackResponse, CoolhandMatchedPattern } from './types.js';
 import { PatternMatchingService } from './services/PatternMatchingService.js';
 import { RequestMonitoringService } from './services/RequestMonitoringService.js';
 import { LoggingService } from './services/LoggingService.js';
@@ -82,6 +82,25 @@ export class Coolhand {
   }
 
   // Public API methods
+
+  /**
+   * Manually submit a single captured LLM request/response to Coolhand.
+   *
+   * Use this for logs that did not flow through automatic monitoring — for example the
+   * coolhand-cli `capture-sessions` tool submitting locally-saved Claude Code / Codex
+   * session turns.
+   *
+   * @param rawRequest The captured request/response payload.
+   * @param options Optional settings. `collector` identifies the submission source and
+   *   overrides the default SDK collector string.
+   * @returns Promise resolving to the created log response, or null if submission failed.
+   */
+  public async logRequest(
+    rawRequest: CoolhandCallData,
+    options?: { collector?: string }
+  ): Promise<CoolhandLogResponse | null> {
+    return this.loggingService.logRequestToAPI(rawRequest, undefined, 'manual', options?.collector);
+  }
 
   /**
    * Create feedback for an LLM request log

--- a/src/services/LoggingService.ts
+++ b/src/services/LoggingService.ts
@@ -16,7 +16,7 @@ export class LoggingService extends BaseService {
     collector?: string
   ): Promise<CoolhandLogResponse | null> {
     // An explicit collector string (e.g. from coolhand-cli) overrides the SDK-derived one.
-    const logData = collector
+    const logData = collector !== undefined
       ? { raw_request: callData, collector }
       : this.addCollectorToData({ raw_request: callData }, collectionMethod);
 

--- a/src/services/LoggingService.ts
+++ b/src/services/LoggingService.ts
@@ -1,4 +1,4 @@
-import { CoolhandCallData, CoolhandLogPayload, CoolhandMatchedPattern } from '../types';
+import { CoolhandCallData, CoolhandLogPayload, CoolhandLogResponse, CoolhandMatchedPattern } from '../types';
 import { CollectionMethod } from '../utils/collector.js';
 import { BaseService, BaseServiceConfig } from './BaseService.js';
 
@@ -9,8 +9,16 @@ export class LoggingService extends BaseService {
     super(config, '/api/v2/llm_request_logs');
   }
 
-  public async logRequestToAPI(callData: CoolhandCallData, matchedPattern?: CoolhandMatchedPattern, collectionMethod?: CollectionMethod): Promise<void> {
-    const logData = this.addCollectorToData({ raw_request: callData }, collectionMethod);
+  public async logRequestToAPI(
+    callData: CoolhandCallData,
+    matchedPattern?: CoolhandMatchedPattern,
+    collectionMethod?: CollectionMethod,
+    collector?: string
+  ): Promise<CoolhandLogResponse | null> {
+    // An explicit collector string (e.g. from coolhand-cli) overrides the SDK-derived one.
+    const logData = collector
+      ? { raw_request: callData, collector }
+      : this.addCollectorToData({ raw_request: callData }, collectionMethod);
 
     const payload: CoolhandLogPayload = {
       llm_request_log: logData
@@ -18,12 +26,14 @@ export class LoggingService extends BaseService {
 
     this.logRequestInfo(callData, matchedPattern);
 
-    await this.sendRequest(
+    const result = await this.sendRequest<CoolhandLogResponse>(
       payload,
       `✅ Successfully logged to API with ID for call #${callData.id}`
     );
 
     this.logSeparator();
+
+    return result;
   }
 
   private logRequestInfo(callData: CoolhandCallData, matchedPattern?: CoolhandMatchedPattern): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,15 @@ export interface CoolhandLogPayload {
   };
 }
 
+export interface CoolhandLogResponse {
+  id?: number;
+  source_api?: string | null;
+  source_api_result?: string | null;
+  llm_provider_unique_id?: string | null;
+  warnings?: string[];
+  [key: string]: unknown;
+}
+
 export interface CoolhandAPIPattern {
   id?: string;
   name: string;

--- a/test/coolhand.test.ts
+++ b/test/coolhand.test.ts
@@ -97,4 +97,76 @@ describe('Coolhand Node Monitor', () => {
       expect(typeof monitor.createFeedback).toBe('function');
     });
   });
+
+  describe('logRequest', () => {
+    const savedFetch = (global as any).fetch;
+
+    afterEach(() => {
+      (global as any).fetch = savedFetch;
+    });
+
+    function buildRawRequest() {
+      return {
+        id: 1,
+        timestamp: '2026-06-02T00:00:00Z',
+        method: 'POST',
+        url: 'claudecode://session/abc/req_123',
+        headers: {},
+        request_body: { model: 'claude-opus-4-8', messages: [{ role: 'user', content: 'Hi' }] },
+        response_body: {
+          id: 'req_123',
+          model: 'claude-opus-4-8',
+          content: [{ type: 'text', text: 'Hello' }],
+          usage: { input_tokens: 5, output_tokens: 2 }
+        },
+        response_headers: null,
+        status_code: 200,
+        protocol: 'claudecode'
+      };
+    }
+
+    function mockFetch(capture: { body?: any }, response: any) {
+      (global as any).fetch = jest.fn().mockImplementation(async (_input: any, options: any) => {
+        capture.body = JSON.parse(options.body);
+        return {
+          ok: true,
+          status: 201,
+          json: jest.fn().mockResolvedValue(response),
+          text: jest.fn().mockResolvedValue('')
+        };
+      });
+    }
+
+    it('submits the raw request and returns the API response', async () => {
+      const capture: { body?: any } = {};
+      mockFetch(capture, { id: 42, source_api: 'claude_code', warnings: [] });
+
+      const monitor = new Coolhand({ apiKey: 'test-key', silent: true });
+      const result = await monitor.logRequest(buildRawRequest() as any);
+
+      expect(capture.body.llm_request_log.raw_request.url).toBe('claudecode://session/abc/req_123');
+      expect(result).toEqual({ id: 42, source_api: 'claude_code', warnings: [] });
+    });
+
+    it('uses an explicit collector when provided', async () => {
+      const capture: { body?: any } = {};
+      mockFetch(capture, { id: 1 });
+
+      const monitor = new Coolhand({ apiKey: 'test-key', silent: true });
+      await monitor.logRequest(buildRawRequest() as any, { collector: 'coolhand-cli/claude-code' });
+
+      expect(capture.body.llm_request_log.collector).toBe('coolhand-cli/claude-code');
+    });
+
+    it('defaults the collector to the SDK string when none is given', async () => {
+      const capture: { body?: any } = {};
+      mockFetch(capture, { id: 1 });
+
+      const monitor = new Coolhand({ apiKey: 'test-key', silent: true });
+      await monitor.logRequest(buildRawRequest() as any);
+
+      expect(capture.body.llm_request_log.collector).toContain('coolhand-node');
+      expect(capture.body.llm_request_log.collector).toContain('manual');
+    });
+  });
 });

--- a/test/debug-mode.test.ts
+++ b/test/debug-mode.test.ts
@@ -156,7 +156,7 @@ describe('Debug/DryRun Mode', () => {
         dryRun: true
       });
 
-      await expect(loggingService.logRequestToAPI(sampleCallData)).resolves.toBeUndefined();
+      await expect(loggingService.logRequestToAPI(sampleCallData)).resolves.toBeNull();
     });
 
     it('should log dry run messages when dryRun=true and not silent', async () => {


### PR DESCRIPTION
Adds a public `logRequest(rawRequest, { collector? })` so callers can submit individually captured LLM request/response payloads outside automatic monitoring (used by coolhand-cli capture-sessions, Coolhand-Labs/coolhand-cli#18).

- `LoggingService.logRequestToAPI` now returns `CoolhandLogResponse | null` and accepts an optional collector override (backward compatible)
- new `CoolhandLogResponse` type