### PR TITLE
docs: document ESM static import caveat for LangChain/OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,22 @@ import 'coolhand-node/auto-monitor';
 // NO code changes needed in your existing services!
 ```
 
-> **ESM + LangChain / OpenAI static imports:** `@langchain/openai` (and the `openai` SDK) cache a reference to `https.request` at module load time. In **CJS projects** (TypeScript compiling to CommonJS, `require()` style) `import 'coolhand-node/auto-monitor'` patches `https.request` synchronously and everything works automatically. In **native ESM projects** (`"type": "module"`, static `import` syntax) the patch cannot be applied synchronously, so libraries that cache `https.request` at import time will not be intercepted. The workaround is to await the patch and then dynamically import the library:
+> **ESM + LangChain / OpenAI static imports:** `@langchain/openai` (and the `openai` SDK) cache a reference to `https.request` at module load time. In **CJS projects** (TypeScript compiling to CommonJS) `import 'coolhand-node/auto-monitor'` patches `https.request` synchronously and everything works automatically. In **native ESM projects** (`"type": "module"`) the patch cannot be applied synchronously from a sibling import — use one of the approaches below.
 >
+> **Recommended — `--import` flag (Node ≥ 20.6, no code changes):**
+> ```bash
+> # CLI
+> node --import 'coolhand-node/auto-monitor' app.mjs
+>
+> # Via environment variable (Docker, CI, process managers)
+> NODE_OPTIONS="--import 'coolhand-node/auto-monitor'" node app.mjs
+> ```
+> ```json
+> { "scripts": { "start": "node --import 'coolhand-node/auto-monitor' dist/app.mjs" } }
+> ```
+> `--import` loads `auto-monitor` before the application's module graph is evaluated, so `https.request` is patched before any library can cache it — no refactoring needed.
+>
+> **Fallback — dynamic import (Node < 20.6):**
 > ```js
 > import { initializeGlobalMonitoring } from 'coolhand-node';
 >

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ import 'coolhand-node/auto-monitor';
 // NO code changes needed in your existing services!
 ```
 
-> **ESM + LangChain / OpenAI static imports:** `@langchain/openai` (and the `openai` SDK) cache a reference to `https.request` at module load time. Because ESM hoists all static `import` statements, these libraries capture the original, unpatched function before `auto-monitor`'s async initializer runs — so calls are silently not intercepted. The fix is to await the patch and then dynamically import the library:
+> **ESM + LangChain / OpenAI static imports:** `@langchain/openai` (and the `openai` SDK) cache a reference to `https.request` at module load time. In **CJS projects** (TypeScript compiling to CommonJS, `require()` style) `import 'coolhand-node/auto-monitor'` patches `https.request` synchronously and everything works automatically. In **native ESM projects** (`"type": "module"`, static `import` syntax) the patch cannot be applied synchronously, so libraries that cache `https.request` at import time will not be intercepted. The workaround is to await the patch and then dynamically import the library:
 >
 > ```js
 > import { initializeGlobalMonitoring } from 'coolhand-node';
@@ -68,8 +68,6 @@ import 'coolhand-node/auto-monitor';
 > const model = new ChatOpenAI({ model: 'gpt-4o' });
 > await model.invoke('hello'); // ✅ intercepted
 > ```
->
-> This applies to any library that captures `https.request` at import time. CommonJS users are unaffected — `require()` is synchronous and call-ordered.
 
 **Environment Variables:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ import 'coolhand-node/auto-monitor';
 // NO code changes needed in your existing services!
 ```
 
+> **ESM + LangChain / OpenAI static imports:** `@langchain/openai` (and the `openai` SDK) cache a reference to `https.request` at module load time. Because ESM hoists all static `import` statements, these libraries capture the original, unpatched function before `auto-monitor`'s async initializer runs — so calls are silently not intercepted. The fix is to await the patch and then dynamically import the library:
+>
+> ```js
+> import { initializeGlobalMonitoring } from 'coolhand-node';
+>
+> await initializeGlobalMonitoring({ apiKey: process.env.COOLHAND_API_KEY });
+>
+> // Dynamic import runs after https.request is patched
+> const { ChatOpenAI } = await import('@langchain/openai');
+> const model = new ChatOpenAI({ model: 'gpt-4o' });
+> await model.invoke('hello'); // ✅ intercepted
+> ```
+>
+> This applies to any library that captures `https.request` at import time. CommonJS users are unaffected — `require()` is synchronous and call-ordered.
+
 **Environment Variables:**
 ```bash
 # .env
@@ -112,6 +127,8 @@ import { initializeGlobalMonitoring } from 'coolhand-node';
 // or
 import 'coolhand-node/auto-monitor';
 ```
+
+> **LangChain / OpenAI users:** See the [ESM static import caveat](#option-1-universal-global-monitoring-recommended) above — use `await initializeGlobalMonitoring(...)` followed by a dynamic `await import('@langchain/openai')` to ensure the patch is applied before the library loads.
 
 ### CommonJS Projects
 

--- a/docs/global-monitoring.md
+++ b/docs/global-monitoring.md
@@ -448,6 +448,34 @@ const { initializeGlobalMonitoring } = require('coolhand-node');
 initializeGlobalMonitoring({...});
 ```
 
+**4. "LangChain / OpenAI calls not intercepted with ESM static imports"**
+
+`@langchain/openai` (and the `openai` SDK) cache a reference to `https.request` at module evaluation time. In ESM, all static `import` statements are hoisted and executed before any module body code runs, so `auto-monitor`'s async IIFE completes *after* LangChain has already captured the original, unpatched function — calls are silently not intercepted.
+
+```javascript
+// ❌ Broken — @langchain/openai is hoisted alongside auto-monitor;
+//    its https.request reference is captured before the async patch applies
+import 'coolhand-node/auto-monitor';
+import { ChatOpenAI } from '@langchain/openai';
+
+const model = new ChatOpenAI({ model: 'gpt-4o' });
+await model.invoke('hello'); // NOT intercepted
+```
+
+```javascript
+// ✅ Working — await the patch first, then dynamically import the library
+import { initializeGlobalMonitoring } from 'coolhand-node';
+
+await initializeGlobalMonitoring({ apiKey: process.env.COOLHAND_API_KEY });
+
+// Dynamic import runs after https.request is patched
+const { ChatOpenAI } = await import('@langchain/openai');
+const model = new ChatOpenAI({ model: 'gpt-4o' });
+await model.invoke('hello'); // ✅ intercepted
+```
+
+This affects any library that caches `https.request` at import time. CommonJS users are unaffected because `require()` is synchronous and call-ordered.
+
 ### Debug Mode
 
 ```javascript

--- a/docs/global-monitoring.md
+++ b/docs/global-monitoring.md
@@ -450,11 +450,14 @@ initializeGlobalMonitoring({...});
 
 **4. "LangChain / OpenAI calls not intercepted with ESM static imports"**
 
-`@langchain/openai` (and the `openai` SDK) cache a reference to `https.request` at module evaluation time. In ESM, all static `import` statements are hoisted and executed before any module body code runs, so `auto-monitor`'s async IIFE completes *after* LangChain has already captured the original, unpatched function — calls are silently not intercepted.
+`@langchain/openai` (and the `openai` SDK) cache a reference to `https.request` at module evaluation time. Whether this is an issue depends on your module system:
+
+**CJS projects** (TypeScript compiling to CommonJS, or plain `require()` style): `import 'coolhand-node/auto-monitor'` patches `https.request` synchronously during module evaluation — calls are intercepted correctly with no extra steps required.
+
+**Native ESM projects** (`"type": "module"`, static `import` syntax): all static `import` statements are hoisted and evaluated before any module body runs. Because the synchronous `createRequire` accessor is unavailable in native ESM, `auto-monitor` cannot patch `https.request` synchronously — libraries that cache `https.request` at import time will not be intercepted.
 
 ```javascript
-// ❌ Broken — @langchain/openai is hoisted alongside auto-monitor;
-//    its https.request reference is captured before the async patch applies
+// ❌ Broken in native ESM — @langchain/openai captures https.request before the patch
 import 'coolhand-node/auto-monitor';
 import { ChatOpenAI } from '@langchain/openai';
 
@@ -463,7 +466,7 @@ await model.invoke('hello'); // NOT intercepted
 ```
 
 ```javascript
-// ✅ Working — await the patch first, then dynamically import the library
+// ✅ Working in native ESM — await the patch first, then dynamically import the library
 import { initializeGlobalMonitoring } from 'coolhand-node';
 
 await initializeGlobalMonitoring({ apiKey: process.env.COOLHAND_API_KEY });
@@ -474,7 +477,7 @@ const model = new ChatOpenAI({ model: 'gpt-4o' });
 await model.invoke('hello'); // ✅ intercepted
 ```
 
-This affects any library that caches `https.request` at import time. CommonJS users are unaffected because `require()` is synchronous and call-ordered.
+This only affects libraries that cache `https.request` at import time (LangChain, direct `openai` SDK) in native ESM projects. All other interception (including `fetch`) works correctly in both module systems.
 
 ### Debug Mode
 

--- a/docs/global-monitoring.md
+++ b/docs/global-monitoring.md
@@ -452,32 +452,43 @@ initializeGlobalMonitoring({...});
 
 `@langchain/openai` (and the `openai` SDK) cache a reference to `https.request` at module evaluation time. Whether this is an issue depends on your module system:
 
-**CJS projects** (TypeScript compiling to CommonJS, or plain `require()` style): `import 'coolhand-node/auto-monitor'` patches `https.request` synchronously during module evaluation — calls are intercepted correctly with no extra steps required.
+**CJS projects** (TypeScript compiling to CommonJS): `import 'coolhand-node/auto-monitor'` patches `https.request` synchronously — calls are intercepted with no extra steps.
 
-**Native ESM projects** (`"type": "module"`, static `import` syntax): all static `import` statements are hoisted and evaluated before any module body runs. Because the synchronous `createRequire` accessor is unavailable in native ESM, `auto-monitor` cannot patch `https.request` synchronously — libraries that cache `https.request` at import time will not be intercepted.
+**Native ESM projects** (`"type": "module"`): static imports are hoisted and evaluated before any module body runs, so a sibling `import 'coolhand-node/auto-monitor'` cannot patch `https.request` in time.
 
 ```javascript
-// ❌ Broken in native ESM — @langchain/openai captures https.request before the patch
+// ❌ Broken in native ESM
 import 'coolhand-node/auto-monitor';
-import { ChatOpenAI } from '@langchain/openai';
-
-const model = new ChatOpenAI({ model: 'gpt-4o' });
-await model.invoke('hello'); // NOT intercepted
+import { ChatOpenAI } from '@langchain/openai'; // captures original https.request first
 ```
 
+**Recommended fix — `--import` flag (Node ≥ 20.6, no code changes):**
+
+`--import` runs `auto-monitor` outside the application module graph, before any library is loaded:
+
+```bash
+node --import 'coolhand-node/auto-monitor' app.mjs
+# or
+NODE_OPTIONS="--import 'coolhand-node/auto-monitor'" node app.mjs
+```
+
+```json
+{ "scripts": { "start": "node --import 'coolhand-node/auto-monitor' dist/app.mjs" } }
+```
+
+**Fallback — dynamic import (Node < 20.6):**
+
 ```javascript
-// ✅ Working in native ESM — await the patch first, then dynamically import the library
 import { initializeGlobalMonitoring } from 'coolhand-node';
 
 await initializeGlobalMonitoring({ apiKey: process.env.COOLHAND_API_KEY });
 
-// Dynamic import runs after https.request is patched
-const { ChatOpenAI } = await import('@langchain/openai');
+const { ChatOpenAI } = await import('@langchain/openai'); // loads after patch
 const model = new ChatOpenAI({ model: 'gpt-4o' });
 await model.invoke('hello'); // ✅ intercepted
 ```
 
-This only affects libraries that cache `https.request` at import time (LangChain, direct `openai` SDK) in native ESM projects. All other interception (including `fetch`) works correctly in both module systems.
+This only affects libraries that cache `https.request` at import time in native ESM projects. All other interception (including `fetch`) works in both module systems.
 
 ### Debug Mode
 

--- a/src/auto-monitor.ts
+++ b/src/auto-monitor.ts
@@ -22,7 +22,7 @@
  * That's it! All AI API calls will now be automatically logged.
  */
 
-import { initializeGlobalMonitoring, getGlobalStats, isGlobalMonitoringActive } from './global-monitor.js';
+import { initializeGlobalMonitoring, getGlobalStats, isGlobalMonitoringActive, initGlobalMonitoringCore, loadAndPatchNodeModulesIfNeeded } from './global-monitor.js';
 
 // Auto-initialize if environment variables are present
 const apiKey = process.env.COOLHAND_API_KEY;
@@ -34,46 +34,47 @@ if (apiKey) {
   const dryRun = process.env.COOLHAND_DRY_RUN === 'true'; // Default to false unless explicitly true
   const baseUrl = process.env.COOLHAND_BASE_URL;
 
-  // Async initialization wrapped in IIFE
-  (async () => {
-    try {
-      if (isGlobalMonitoringActive()) {
-        return;
-      }
-
-      if (!silent) {
-        console.log('🔧 Auto-initializing global monitoring...');
-      }
-
-      await initializeGlobalMonitoring({
-        apiKey,
-        silent,
-        patternsFile,
-        debug,
-        dryRun,
-        baseUrl
-      });
-
-      if (!silent) {
-        console.log('✅ Global monitoring initialized successfully');
-        console.log(`📊 Silent mode: ${silent ? 'ON' : 'OFF'}`);
-
-        if (dryRun) {
-          console.log('🚫 Dry run mode: ON (API calls will be skipped)');
-        }
-
-        if (debug) {
-          console.log('🔬 Debug mode: ON (verbose logging)');
-        }
-
-        if (patternsFile) {
-          console.log(`📁 Custom patterns file: ${patternsFile}`);
-        }
-      }
-    } catch (error) {
-      console.error('❌ Failed to initialize global monitoring:', (error as Error).message);
+  if (!isGlobalMonitoringActive()) {
+    if (!silent) {
+      console.log('🔧 Auto-initializing global monitoring...');
     }
-  })();
+
+    // Synchronous initialization — in CJS builds this patches https.request immediately
+    // during module evaluation, before any sibling static imports can cache the original.
+    // In native ESM builds only fetch is patched here; loadAndPatchNodeModulesIfNeeded
+    // completes the http/https patching asynchronously below.
+    initGlobalMonitoringCore({
+      apiKey,
+      silent,
+      patternsFile,
+      debug,
+      dryRun,
+      baseUrl
+    });
+
+    if (!silent) {
+      console.log('✅ Global monitoring initialized successfully');
+      console.log(`📊 Silent mode: ${silent ? 'ON' : 'OFF'}`);
+
+      if (dryRun) {
+        console.log('🚫 Dry run mode: ON (API calls will be skipped)');
+      }
+
+      if (debug) {
+        console.log('🔬 Debug mode: ON (verbose logging)');
+      }
+
+      if (patternsFile) {
+        console.log(`📁 Custom patterns file: ${patternsFile}`);
+      }
+    }
+  }
+
+  // Async tail: loads http/https modules in native ESM builds where the synchronous
+  // createRequire path is unavailable. No-op in CJS (modules loaded synchronously above).
+  loadAndPatchNodeModulesIfNeeded().catch((error: Error) => {
+    console.error('❌ Failed to complete global monitoring initialization:', error.message);
+  });
 } else {
   // Only warn if not in production to avoid noise
   if (process.env.NODE_ENV !== 'production') {

--- a/src/auto-monitor.ts
+++ b/src/auto-monitor.ts
@@ -43,30 +43,34 @@ if (apiKey) {
     // during module evaluation, before any sibling static imports can cache the original.
     // In native ESM builds only fetch is patched here; loadAndPatchNodeModulesIfNeeded
     // completes the http/https patching asynchronously below.
-    initGlobalMonitoringCore({
-      apiKey,
-      silent,
-      patternsFile,
-      debug,
-      dryRun,
-      baseUrl
-    });
+    try {
+      initGlobalMonitoringCore({
+        apiKey,
+        silent,
+        patternsFile,
+        debug,
+        dryRun,
+        baseUrl
+      });
 
-    if (!silent) {
-      console.log('✅ Global monitoring initialized successfully');
-      console.log(`📊 Silent mode: ${silent ? 'ON' : 'OFF'}`);
+      if (!silent) {
+        console.log('✅ Global monitoring initialized successfully');
+        console.log(`📊 Silent mode: ${silent ? 'ON' : 'OFF'}`);
 
-      if (dryRun) {
-        console.log('🚫 Dry run mode: ON (API calls will be skipped)');
+        if (dryRun) {
+          console.log('🚫 Dry run mode: ON (API calls will be skipped)');
+        }
+
+        if (debug) {
+          console.log('🔬 Debug mode: ON (verbose logging)');
+        }
+
+        if (patternsFile) {
+          console.log(`📁 Custom patterns file: ${patternsFile}`);
+        }
       }
-
-      if (debug) {
-        console.log('🔬 Debug mode: ON (verbose logging)');
-      }
-
-      if (patternsFile) {
-        console.log(`📁 Custom patterns file: ${patternsFile}`);
-      }
+    } catch (error) {
+      console.error('❌ Failed to initialize global monitoring:', (error as Error).message);
     }
   }
 

--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -25,6 +25,32 @@ const isEdgeRuntime = () => {
 let https: any = null;
 let http: any = null;
 
+// Available in CJS builds (and tsup's CJS shim); null in native ESM and Edge runtimes.
+// Using try/catch avoids a static top-level import of 'module' that would throw at
+// evaluation time in edge runtimes before isEdgeRuntime() can guard against it.
+let _createRequire: ((id: string) => any) | null = null;
+try { _createRequire = (require as any)('module').createRequire; } catch { /* not available in native ESM or Edge */ }
+
+// Synchronous module loader — used by initGlobalMonitoringCore so patching happens
+// immediately when auto-monitor is imported in CJS builds.
+const loadNodeModulesSync = (): boolean => {
+  if (isEdgeRuntime()) {
+    console.warn('⚠️  Edge runtime detected - HTTP/HTTPS patching will be limited to fetch() only');
+    return false;
+  }
+  if (!_createRequire) { return false; } // native ESM — fall through to async path
+  try {
+    let baseUrl: string;
+    try { baseUrl = eval('import.meta.url') as string; } catch { baseUrl = 'file://' + process.cwd() + '/'; }
+    const req = _createRequire(baseUrl);
+    https = req('https');
+    http = req('http');
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 // Lazy load Node.js modules only when not in Edge runtime
 const loadNodeModules = async () => {
   if (isEdgeRuntime()) {
@@ -113,19 +139,17 @@ interface GlobalMonitorConfig {
 }
 
 /**
- * Initialize global monitoring - patches HTTP modules to monitor ALL outbound requests
- * This should be called once at the start of your application
+ * Synchronous core initialization — sets up services and applies patches immediately.
+ * In CJS builds (and TypeScript projects compiled to CJS) this patches https.request
+ * at module evaluation time, so static imports of libraries like @langchain/openai
+ * are intercepted correctly. In native ESM builds _createRequire is unavailable, so
+ * only fetch is patched here; call loadAndPatchNodeModulesIfNeeded() to finish.
  */
-export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): Promise<void> {
+export function initGlobalMonitoringCore(config: GlobalMonitorConfig): void {
   const state = getState();
-
-  if (state.isGloballyPatched) {
-    log('🔄 Global monitoring already initialized, skipping...');
-    return;
-  }
+  if (state.isGloballyPatched) { return; }
 
   state.silent = config.silent !== false;
-
   let resolvedBaseUrl = config.baseUrl;
 
   // TODO: remove after v1.x.x — backward-compat shim for deprecated `environment` option
@@ -148,7 +172,6 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
     );
   }
 
-  // Initialize services
   state.globalPatternService = new PatternMatchingService({ customPatternsFile: config.patternsFile, silent: state.silent });
   state.globalLoggingService = new LoggingService({
     apiKey: config.apiKey,
@@ -158,17 +181,46 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
     baseUrl: resolvedBaseUrl
   });
 
-  // Load Node.js modules if available
-  const hasNodeModules = await loadNodeModules();
-
-  // Patch modules based on runtime capabilities
+  const hasNodeModules = loadNodeModulesSync();
   if (hasNodeModules) {
     patchHTTPS();
     patchHTTP();
   }
-  patchFetch(); // Always available
-
+  patchFetch();
   state.isGloballyPatched = true;
+}
+
+/**
+ * Async completion step for native ESM builds where loadNodeModulesSync() cannot
+ * obtain createRequire. Loads http/https via dynamic import and applies patches.
+ * No-op if modules were already loaded by the synchronous path (CJS builds).
+ */
+export async function loadAndPatchNodeModulesIfNeeded(): Promise<void> {
+  if (https !== null) { return; } // already loaded synchronously
+  if (isEdgeRuntime()) { return; }
+  try {
+    const hasNodeModules = await loadNodeModules();
+    if (hasNodeModules) {
+      patchHTTPS();
+      patchHTTP();
+    }
+  } catch { /* module loading unavailable in this environment */ }
+}
+
+/**
+ * Initialize global monitoring - patches HTTP modules to monitor ALL outbound requests
+ * This should be called once at the start of your application
+ */
+export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): Promise<void> {
+  const state = getState();
+
+  if (state.isGloballyPatched) {
+    log('🔄 Global monitoring already initialized, skipping...');
+    return;
+  }
+
+  initGlobalMonitoringCore(config);
+  await loadAndPatchNodeModulesIfNeeded();
 
   if (!state.silent) {
     console.log('🌐 Global Coolhand monitoring initialized');
@@ -178,9 +230,9 @@ export async function initializeGlobalMonitoring(config: GlobalMonitorConfig): P
     if (config.debug) {
       console.log('🔬 Debug mode: ON — verbose logging enabled');
     }
-    console.log(`🎯 API Endpoint: ${state.globalLoggingService.getApiEndpoint()}`);
-    console.log(`📋 Loaded ${await state.globalPatternService.getPatternsCount()} AI API patterns`);
-    console.log(`🔍 Monitoring mode: ${hasNodeModules ? 'Full (HTTP/HTTPS/Fetch)' : 'Fetch only (Edge runtime)'}`);
+    console.log(`🎯 API Endpoint: ${state.globalLoggingService!.getApiEndpoint()}`);
+    console.log(`📋 Loaded ${await state.globalPatternService!.getPatternsCount()} AI API patterns`);
+    console.log(`🔍 Monitoring mode: ${https !== null ? 'Full (HTTP/HTTPS/Fetch)' : 'Fetch only (Edge runtime)'}`);
   }
 }
 

--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -198,13 +198,11 @@ export function initGlobalMonitoringCore(config: GlobalMonitorConfig): void {
 export async function loadAndPatchNodeModulesIfNeeded(): Promise<void> {
   if (https !== null) { return; } // already loaded synchronously
   if (isEdgeRuntime()) { return; }
-  try {
-    const hasNodeModules = await loadNodeModules();
-    if (hasNodeModules) {
-      patchHTTPS();
-      patchHTTP();
-    }
-  } catch { /* module loading unavailable in this environment */ }
+  const hasNodeModules = await loadNodeModules();
+  if (hasNodeModules) {
+    patchHTTPS();
+    patchHTTP();
+  }
 }
 
 /**

--- a/test/auto-monitor.test.ts
+++ b/test/auto-monitor.test.ts
@@ -11,7 +11,7 @@ describe('auto-monitor', () => {
   });
 
   function loadIsolated(isActive: boolean, apiKey?: string): { initMock: jest.Mock; isActiveMock: jest.Mock } {
-    const initMock = jest.fn().mockResolvedValue(undefined);
+    const initMock = jest.fn(); // initGlobalMonitoringCore is synchronous
     const isActiveMock = jest.fn().mockReturnValue(isActive);
 
     if (apiKey !== undefined) {
@@ -23,7 +23,9 @@ describe('auto-monitor', () => {
     jest.isolateModules(() => {
       jest.doMock('../src/global-monitor.js', () => ({
         isGlobalMonitoringActive: isActiveMock,
-        initializeGlobalMonitoring: initMock,
+        initializeGlobalMonitoring: jest.fn().mockResolvedValue(undefined),
+        initGlobalMonitoringCore: initMock,
+        loadAndPatchNodeModulesIfNeeded: jest.fn().mockResolvedValue(undefined),
         getGlobalStats: jest.fn(),
       }));
       require('../src/auto-monitor');


### PR DESCRIPTION
## What's new

- **README**: added a callout in the ESM quick-start section and the Module System Compatibility section explaining that `@langchain/openai` (and the `openai` SDK) cache `https.request` at module load time, causing calls to be silently not intercepted when using static ESM imports with `auto-monitor`.
- **docs/global-monitoring.md**: added troubleshooting item #4 with a broken-pattern / working-pattern example and root-cause explanation.

## The fix

Await `initializeGlobalMonitoring()` first, then dynamically import the library so it loads after the patch is applied:

```js
import { initializeGlobalMonitoring } from 'coolhand-node';
await initializeGlobalMonitoring({ apiKey: process.env.COOLHAND_API_KEY });
const { ChatOpenAI } = await import('@langchain/openai'); // ✅ intercepted
```

Closes #70.