### PR TITLE
feat: filter non-inference Anthropic GET calls before ingestion

### DIFF
--- a/src/global-monitor.ts
+++ b/src/global-monitor.ts
@@ -10,6 +10,7 @@ import { PatternMatchingService } from './services/PatternMatchingService.js';
 import { LoggingService } from './services/LoggingService.js';
 import { parseBody } from './utils/parse-body.js';
 import { decompressBuffer } from './utils/decompress.js';
+import { isNonInferenceURL } from './non-inference-filter.js';
 
 type HttpClientRequest = any; // Will be properly typed when http is loaded
 type HttpIncomingMessage = any; // Will be properly typed when http is loaded
@@ -393,6 +394,10 @@ function patchHTTPS(): void {
               return originalRequest.call(this, options as any, callback as any);
             }
 
+            if (isNonInferenceURL(buildURL(options, 'https'), method)) {
+              return originalRequest.call(this, options as any, callback as any);
+            }
+
             log(`🎯 INTERCEPTING ${matchedPattern.pattern.name} HTTPS call`);
             return interceptRequest(originalRequest, options, callback, 'https', matchedPattern);
           }
@@ -428,6 +433,10 @@ function patchHTTPS(): void {
 
             if (isRequestActive(requestId)) {
               log(`🔄 Skipping duplicate HTTPS GET: ${buildURL(options, 'https')}`);
+              return originalGet.call(this, options as any, callback as any);
+            }
+
+            if (isNonInferenceURL(buildURL(options, 'https'), 'GET')) {
               return originalGet.call(this, options as any, callback as any);
             }
 
@@ -475,6 +484,10 @@ function patchHTTP(): void {
               return originalRequest.call(this, options as any, callback as any);
             }
 
+            if (isNonInferenceURL(buildURL(options, 'http'), method)) {
+              return originalRequest.call(this, options as any, callback as any);
+            }
+
             log(`🎯 INTERCEPTING ${matchedPattern.pattern.name} HTTP call`);
             return interceptRequest(originalRequest, options, callback, 'http', matchedPattern);
           }
@@ -510,6 +523,10 @@ function patchHTTP(): void {
 
             if (isRequestActive(requestId)) {
               log(`🔄 Skipping duplicate HTTP GET: ${buildURL(options, 'http')}`);
+              return originalGet.call(this, options as any, callback as any);
+            }
+
+            if (isNonInferenceURL(buildURL(options, 'http'), 'GET')) {
               return originalGet.call(this, options as any, callback as any);
             }
 
@@ -551,6 +568,10 @@ function patchFetch(): void {
 
         if (isIdempotentMethod(method) && isRequestActive(requestId)) {
           log(`🔄 Skipping duplicate FETCH: ${method} ${urlStr}`);
+          return originalFetch.call(this, url, options);
+        }
+
+        if (isNonInferenceURL(urlStr, method)) {
           return originalFetch.call(this, url, options);
         }
 

--- a/src/non-inference-filter.ts
+++ b/src/non-inference-filter.ts
@@ -1,0 +1,15 @@
+export const IGNORED_GET_PATH_PATTERNS: readonly RegExp[] = Object.freeze([
+  /^\/api\/directory\/servers(\?.*)?$/,             // MCP server directory listing
+  /^\/v1\/environments\/[^/]+\/work\/poll(\?.*)?$/  // managed-agents environment polling
+]);
+
+export function isNonInferenceURL(url: string, method: string): boolean {
+  if (method.toUpperCase() !== 'GET') { return false; }
+  try {
+    const u = new URL(url);
+    if (u.hostname !== 'api.anthropic.com') { return false; }
+    return IGNORED_GET_PATH_PATTERNS.some(p => p.test(u.pathname + u.search));
+  } catch {
+    return false;
+  }
+}

--- a/src/services/RequestMonitoringService.ts
+++ b/src/services/RequestMonitoringService.ts
@@ -4,6 +4,7 @@ import { CoolhandCallData, CoolhandRequestOptions, CoolhandMatchedPattern } from
 import { PatternMatchingService } from './PatternMatchingService.js';
 import { parseBody } from '../utils/parse-body.js';
 import { decompressBuffer } from '../utils/decompress.js';
+import { isNonInferenceURL } from '../non-inference-filter.js';
 
 export class RequestMonitoringService {
   private callCounter: number = 0;
@@ -58,6 +59,10 @@ export class RequestMonitoringService {
               if (monitor.isExcluded(options, 'https')) {
                 return originalRequest.call(this, options as any, callback as any);
               }
+              const method = typeof options === 'object' && 'method' in options ? (options as any).method || 'GET' : 'GET';
+              if (isNonInferenceURL(monitor.buildURL(options, 'https'), method)) {
+                return originalRequest.call(this, options as any, callback as any);
+              }
               monitor.log(`🎯 INTERCEPTING ${matchedPattern.pattern.name} HTTPS call`);
               return monitor.interceptRequest(originalRequest, options, callback, 'https', matchedPattern);
             }
@@ -83,6 +88,9 @@ export class RequestMonitoringService {
 
             if (matchedPattern) {
               if (monitor.isExcluded(options, 'https')) {
+                return originalGet.call(this, options as any, callback as any);
+              }
+              if (isNonInferenceURL(monitor.buildURL(options, 'https'), 'GET')) {
                 return originalGet.call(this, options as any, callback as any);
               }
               monitor.log(`🎯 INTERCEPTING ${matchedPattern.pattern.name} HTTPS GET`);
@@ -118,6 +126,10 @@ export class RequestMonitoringService {
               if (monitor.isExcluded(options, 'http')) {
                 return originalRequest.call(this, options as any, callback as any);
               }
+              const method = typeof options === 'object' && 'method' in options ? (options as any).method || 'GET' : 'GET';
+              if (isNonInferenceURL(monitor.buildURL(options, 'http'), method)) {
+                return originalRequest.call(this, options as any, callback as any);
+              }
               monitor.log(`🎯 INTERCEPTING ${matchedPattern.pattern.name} HTTP call`);
               return monitor.interceptRequest(originalRequest, options, callback, 'http', matchedPattern);
             }
@@ -143,6 +155,9 @@ export class RequestMonitoringService {
 
             if (matchedPattern) {
               if (monitor.isExcluded(options, 'http')) {
+                return originalGet.call(this, options as any, callback as any);
+              }
+              if (isNonInferenceURL(monitor.buildURL(options, 'http'), 'GET')) {
                 return originalGet.call(this, options as any, callback as any);
               }
               monitor.log(`🎯 INTERCEPTING ${matchedPattern.pattern.name} HTTP GET`);
@@ -175,6 +190,10 @@ export class RequestMonitoringService {
 
         if (matchedPattern) {
           if (monitor.isExcluded(urlStr, 'https')) {
+            return originalFetch.call(this, url, options);
+          }
+          const method = (options as RequestInit)?.method || 'GET';
+          if (isNonInferenceURL(urlStr, method)) {
             return originalFetch.call(this, url, options);
           }
           monitor.log(`🎯 INTERCEPTING ${matchedPattern.pattern.name} FETCH call`);

--- a/test/non-inference-filter.test.ts
+++ b/test/non-inference-filter.test.ts
@@ -1,0 +1,101 @@
+import { IGNORED_GET_PATH_PATTERNS, isNonInferenceURL } from '../src/non-inference-filter';
+
+describe('IGNORED_GET_PATH_PATTERNS', () => {
+  it('is frozen', () => {
+    expect(Object.isFrozen(IGNORED_GET_PATH_PATTERNS)).toBe(true);
+  });
+
+  it('contains exactly two patterns', () => {
+    expect(IGNORED_GET_PATH_PATTERNS).toHaveLength(2);
+  });
+
+  it('matches /api/directory/servers', () => {
+    expect(IGNORED_GET_PATH_PATTERNS[0].test('/api/directory/servers')).toBe(true);
+  });
+
+  it('matches /api/directory/servers with query string', () => {
+    expect(IGNORED_GET_PATH_PATTERNS[0].test('/api/directory/servers?foo=bar')).toBe(true);
+  });
+
+  it('does not match /api/directory/servers/extra', () => {
+    expect(IGNORED_GET_PATH_PATTERNS[0].test('/api/directory/servers/extra')).toBe(false);
+  });
+
+  it('matches /v1/environments/:id/work/poll', () => {
+    expect(IGNORED_GET_PATH_PATTERNS[1].test('/v1/environments/abc123/work/poll')).toBe(true);
+  });
+
+  it('matches /v1/environments/:id/work/poll with query string', () => {
+    expect(IGNORED_GET_PATH_PATTERNS[1].test('/v1/environments/abc123/work/poll?timeout=20')).toBe(true);
+  });
+
+  it('does not match env id containing a slash (two-segment env id)', () => {
+    expect(IGNORED_GET_PATH_PATTERNS[1].test('/v1/environments/abc/123/work/poll')).toBe(false);
+  });
+
+  it('does not match /v1/environments/:id/work/poll/extra', () => {
+    expect(IGNORED_GET_PATH_PATTERNS[1].test('/v1/environments/abc123/work/poll/extra')).toBe(false);
+  });
+});
+
+describe('isNonInferenceURL', () => {
+  describe('drops ignored Anthropic GET paths', () => {
+    it('drops GET /api/directory/servers', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com/api/directory/servers', 'GET')).toBe(true);
+    });
+
+    it('drops GET /api/directory/servers with query string', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com/api/directory/servers?page=1', 'GET')).toBe(true);
+    });
+
+    it('drops GET /v1/environments/:id/work/poll', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com/v1/environments/env_abc123/work/poll', 'GET')).toBe(true);
+    });
+
+    it('drops GET /v1/environments/:id/work/poll with query string', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com/v1/environments/env_abc123/work/poll?timeout=20', 'GET')).toBe(true);
+    });
+
+    it('is case-insensitive for method', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com/api/directory/servers', 'get')).toBe(true);
+    });
+  });
+
+  describe('does NOT drop non-matching cases', () => {
+    it('does not drop POST to an ignored path', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com/api/directory/servers', 'POST')).toBe(false);
+    });
+
+    it('does not drop POST to the poll endpoint', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com/v1/environments/env_abc123/work/poll', 'POST')).toBe(false);
+    });
+
+    it('does not drop GET to a different host (openai.com)', () => {
+      expect(isNonInferenceURL('https://api.openai.com/api/directory/servers', 'GET')).toBe(false);
+    });
+
+    it('does not drop GET to a different Anthropic path', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com/v1/messages', 'GET')).toBe(false);
+    });
+
+    it('does not drop GET /api/directory/servers/extra (suffix not allowed)', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com/api/directory/servers/extra', 'GET')).toBe(false);
+    });
+
+    it('does not drop GET to Bedrock (different host, similar path)', () => {
+      expect(isNonInferenceURL('https://bedrock.amazonaws.com/v1/environments/abc/work/poll', 'GET')).toBe(false);
+    });
+
+    it('does not drop GET to a subdomain of api.anthropic.com (exact host match)', () => {
+      expect(isNonInferenceURL('https://foo.api.anthropic.com/api/directory/servers', 'GET')).toBe(false);
+    });
+
+    it('does not drop GET to a host that merely contains api.anthropic.com as a substring', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com.evil.com/api/directory/servers', 'GET')).toBe(false);
+    });
+
+    it('returns false for malformed URL', () => {
+      expect(isNonInferenceURL('not-a-url', 'GET')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## What's new

- **`src/non-inference-filter.ts`** — new module with two exports:
  - `IGNORED_GET_PATH_PATTERNS`: frozen `RegExp[]` matching the two noisy Anthropic operational paths
  - `isNonInferenceURL(url, method)`: pure helper that returns `true` when a request should be dropped — GET only, exact hostname match (`api.anthropic.com`), path-anchored regexes

## What changed

The following Anthropic GET endpoints are now silently dropped before reaching Coolhand's ingestion endpoint:

- `GET /api/directory/servers` — MCP server directory listing (claude.ai browser sessions)
- `GET /v1/environments/:id/work/poll` — managed-agents environment work polling

The filter is applied at all six interception sites in both `RequestMonitoringService` and `global-monitor` (https.request, https.get, http.request, http.get, fetch). POST requests, requests to other hosts, and unlisted Anthropic paths are unaffected.

Test coverage in `test/non-inference-filter.test.ts` (23 cases) verifies correct filtering and all boundary conditions including hostname-suffix bypass attempts.

Closes #75.