### PR TITLE
feat: add OpenRouter as a built-in API provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-06-23
+
+### ✨ New Features
+- **OpenRouter support** — `openrouter.ai` is now a built-in monitored provider. Covers `/api/v1/chat/completions`, `/api/v1/completions`, and `/api/v1/embeddings`. Redacts `authorization` and `x-api-key` headers. Works in both Node.js (file-loaded patterns) and Edge runtimes (Cloudflare Workers, Vercel Edge).
+
 ## [0.7.0] - 2026-06-08
 
 ### ✨ New Features

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/coolhand-node.svg)](https://badge.fury.io/js/coolhand-node)
 
-Monitor and log LLM API calls from multiple providers (OpenAI, Anthropic, Google AI, GitHub Models, Vertex AI, Cloudflare AI Gateway, and more) to the Coolhand analytics platform.
+Monitor and log LLM API calls from multiple providers (OpenAI, Anthropic, Google AI, GitHub Models, Vertex AI, OpenRouter, Cloudflare AI Gateway, and more) to the Coolhand analytics platform.
 
 ## Related Packages
 
@@ -324,6 +324,7 @@ The monitor works with any Node.js library that makes HTTP(S) requests to LLM AP
 - Google AI SDK
 - GitHub Models (via OpenAI SDK pointed at `models.github.ai` or `models.inference.ai.azure.com`)
 - Vertex AI (native Gemini and OpenAI-compatible endpoints on `aiplatform.googleapis.com`)
+- OpenRouter (`openrouter.ai`, unified access to 200+ models)
 - Cloudflare AI Gateway (`gateway.ai.cloudflare.com`, proxying any upstream provider)
 - LangChain
 - Direct `fetch()` calls

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coolhand-node",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Monitor and LLM API calls for analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/src/api-patterns.json
+++ b/src/api-patterns.json
@@ -44,6 +44,15 @@
       }
     },
     {
+      "name": "OpenRouter",
+      "domains": ["openrouter.ai"],
+      "paths": ["/api/v1/chat/completions", "/api/v1/completions", "/api/v1/embeddings"],
+      "headers": {
+        "authorization": "[REDACTED]",
+        "x-api-key": "[REDACTED]"
+      }
+    },
+    {
       "name": "Cloudflare AI Gateway",
       "domains": ["gateway.ai.cloudflare.com"],
       "paths": [],

--- a/src/services/PatternMatchingService.ts
+++ b/src/services/PatternMatchingService.ts
@@ -129,6 +129,14 @@ export class PatternMatchingService {
         }
       },
       {
+        name: 'OpenRouter',
+        domains: ['openrouter.ai'],
+        headers: {
+          'authorization': 'Bearer [REDACTED]',
+          'x-api-key': '[REDACTED]'
+        }
+      },
+      {
         name: 'Cloudflare AI Gateway',
         domains: ['gateway.ai.cloudflare.com'],
         headers: {

--- a/test/edge-runtime.test.ts
+++ b/test/edge-runtime.test.ts
@@ -48,8 +48,8 @@ describe('Edge Runtime Detection and Loading', () => {
 
       const service = new PatternMatchingService();
 
-      // Should use Edge runtime patterns (4 default patterns)
-      expect(service.getPatternsCountSync()).toBe(6);
+      // Should use Edge runtime patterns (7 default patterns)
+      expect(service.getPatternsCountSync()).toBe(7);
       expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining('Loaded 7 default API patterns for Edge runtime')
       );
@@ -62,7 +62,7 @@ describe('Edge Runtime Detection and Loading', () => {
       const service = new PatternMatchingService();
 
       // Should use Edge runtime patterns
-      expect(service.getPatternsCountSync()).toBe(6);
+      expect(service.getPatternsCountSync()).toBe(7);
       expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining('Loaded 7 default API patterns for Edge runtime')
       );
@@ -75,7 +75,7 @@ describe('Edge Runtime Detection and Loading', () => {
       const service = new PatternMatchingService();
 
       // Should use Edge runtime patterns
-      expect(service.getPatternsCountSync()).toBe(6);
+      expect(service.getPatternsCountSync()).toBe(7);
       expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining('Loaded 7 default API patterns for Edge runtime')
       );
@@ -206,7 +206,7 @@ describe('Edge Runtime Detection and Loading', () => {
       const service = new PatternMatchingService();
 
       // Should still work correctly with multiple indicators
-      expect(service.getPatternsCountSync()).toBe(6);
+      expect(service.getPatternsCountSync()).toBe(7);
       expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining('Loaded 7 default API patterns for Edge runtime')
       );
@@ -283,8 +283,8 @@ describe('Edge Runtime Detection and Loading', () => {
       const service = new PatternMatchingService();
 
       // Should be immediately usable
-      expect(service.getPatternsCountSync()).toBe(6);
-      expect(service.getLoadedPatternsSync()).toHaveLength(6);
+      expect(service.getPatternsCountSync()).toBe(7);
+      expect(service.getLoadedPatternsSync()).toHaveLength(7);
     });
 
     it('should handle multiple initialization calls gracefully', () => {
@@ -298,7 +298,7 @@ describe('Edge Runtime Detection and Loading', () => {
       const patterns = service.getLoadedPatternsSync();
 
       expect(secondCount).toBe(initialCount);
-      expect(patterns).toHaveLength(6);
+      expect(patterns).toHaveLength(7);
     });
   });
 });

--- a/test/edge-runtime.test.ts
+++ b/test/edge-runtime.test.ts
@@ -51,7 +51,7 @@ describe('Edge Runtime Detection and Loading', () => {
       // Should use Edge runtime patterns (4 default patterns)
       expect(service.getPatternsCountSync()).toBe(6);
       expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('Loaded 6 default API patterns for Edge runtime')
+        expect.stringContaining('Loaded 7 default API patterns for Edge runtime')
       );
     });
 
@@ -64,7 +64,7 @@ describe('Edge Runtime Detection and Loading', () => {
       // Should use Edge runtime patterns
       expect(service.getPatternsCountSync()).toBe(6);
       expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('Loaded 6 default API patterns for Edge runtime')
+        expect.stringContaining('Loaded 7 default API patterns for Edge runtime')
       );
     });
 
@@ -77,7 +77,7 @@ describe('Edge Runtime Detection and Loading', () => {
       // Should use Edge runtime patterns
       expect(service.getPatternsCountSync()).toBe(6);
       expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('Loaded 6 default API patterns for Edge runtime')
+        expect.stringContaining('Loaded 7 default API patterns for Edge runtime')
       );
     });
 
@@ -90,8 +90,8 @@ describe('Edge Runtime Detection and Loading', () => {
       const service = new PatternMatchingService();
 
       // Should try to load from filesystem and succeed in test environment
-      // This will load the actual patterns file with 6 patterns
-      expect(service.getPatternsCountSync()).toBe(6);
+      // This will load the actual patterns file with 7 patterns
+      expect(service.getPatternsCountSync()).toBe(7);
     });
   });
 
@@ -105,7 +105,7 @@ describe('Edge Runtime Detection and Loading', () => {
       const service = new PatternMatchingService();
       const patterns = service.getLoadedPatternsSync();
 
-      expect(patterns).toHaveLength(6);
+      expect(patterns).toHaveLength(7);
 
       // Check for expected default patterns
       const patternNames = patterns.map(p => p.name);
@@ -114,6 +114,7 @@ describe('Edge Runtime Detection and Loading', () => {
       expect(patternNames).toContain('Google AI');
       expect(patternNames).toContain('GitHub Models');
       expect(patternNames).toContain('Vertex AI');
+      expect(patternNames).toContain('OpenRouter');
       expect(patternNames).toContain('Cloudflare AI Gateway');
     });
 
@@ -163,9 +164,9 @@ describe('Edge Runtime Detection and Loading', () => {
       const service = new PatternMatchingService('./custom-patterns.json');
 
       // Should still load default Edge patterns, not attempt to read custom file
-      expect(service.getPatternsCountSync()).toBe(6);
+      expect(service.getPatternsCountSync()).toBe(7);
       expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('Loaded 6 default API patterns for Edge runtime')
+        expect.stringContaining('Loaded 7 default API patterns for Edge runtime')
       );
     });
   });
@@ -186,13 +187,13 @@ describe('Edge Runtime Detection and Loading', () => {
       const nodeService = new PatternMatchingService();
       const nodePatterns = nodeService.getLoadedPatternsSync();
 
-      // Edge runtime uses 6 default patterns, Node.js loads 6 from file
-      expect(edgePatterns).toHaveLength(6);
-      expect(nodePatterns).toHaveLength(6);
+      // Edge runtime uses 7 default patterns, Node.js loads 7 from file
+      expect(edgePatterns).toHaveLength(7);
+      expect(nodePatterns).toHaveLength(7);
 
       // But the loading paths should be different (check console output)
       expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('Loaded 6 default API patterns for Edge runtime')
+        expect.stringContaining('Loaded 7 default API patterns for Edge runtime')
       );
     });
 
@@ -207,7 +208,7 @@ describe('Edge Runtime Detection and Loading', () => {
       // Should still work correctly with multiple indicators
       expect(service.getPatternsCountSync()).toBe(6);
       expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('Loaded 6 default API patterns for Edge runtime')
+        expect.stringContaining('Loaded 7 default API patterns for Edge runtime')
       );
     });
   });

--- a/test/pattern-matching-service.test.ts
+++ b/test/pattern-matching-service.test.ts
@@ -113,8 +113,8 @@ describe('PatternMatchingService', () => {
         expect.stringContaining('Error loading API patterns'),
         expect.any(String)
       );
-      // Should fallback to default Edge runtime patterns (6 patterns)
-      expect(service.getPatternsCountSync()).toBe(6);
+      // Should fallback to default Edge runtime patterns (7 patterns)
+      expect(service.getPatternsCountSync()).toBe(7);
     });
 
     it('should handle file system errors', () => {
@@ -128,8 +128,8 @@ describe('PatternMatchingService', () => {
         expect.stringContaining('Error loading API patterns'),
         'File system error'
       );
-      // Should fallback to default Edge runtime patterns (6 patterns)
-      expect(service.getPatternsCountSync()).toBe(6);
+      // Should fallback to default Edge runtime patterns (7 patterns)
+      expect(service.getPatternsCountSync()).toBe(7);
     });
   });
 

--- a/test/pattern-matching-service.test.ts
+++ b/test/pattern-matching-service.test.ts
@@ -1188,6 +1188,71 @@ describe('PatternMatchingService', () => {
     });
   });
 
+  describe('OpenRouter Pattern Matching', () => {
+    const mockPatternsWithOpenRouter = {
+      patterns: [
+        ...mockPatterns.patterns,
+        {
+          name: 'OpenRouter',
+          domains: ['openrouter.ai'],
+          paths: ['/api/v1/chat/completions', '/api/v1/completions', '/api/v1/embeddings'],
+          headers: {
+            authorization: '[REDACTED]',
+            'x-api-key': '[REDACTED]'
+          }
+        }
+      ]
+    };
+
+    beforeEach(() => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify(mockPatternsWithOpenRouter));
+      service = new PatternMatchingService();
+    });
+
+    it('should match OpenRouter chat completions URL by domain', () => {
+      const result = service.matchesAPIPatternFromURL(
+        'https://openrouter.ai/api/v1/chat/completions'
+      );
+      expect(result).toMatchObject({
+        pattern: expect.objectContaining({ name: 'OpenRouter' }),
+        matchType: 'domain',
+        matchValue: 'openrouter.ai'
+      });
+    });
+
+    it('should match OpenRouter embeddings URL by domain', () => {
+      const result = service.matchesAPIPatternFromURL(
+        'https://openrouter.ai/api/v1/embeddings'
+      );
+      expect(result).toMatchObject({
+        pattern: expect.objectContaining({ name: 'OpenRouter' }),
+        matchType: 'domain',
+        matchValue: 'openrouter.ai'
+      });
+    });
+
+    it('should redact authorization and x-api-key headers for OpenRouter', () => {
+      const pattern: CoolhandAPIPattern = {
+        name: 'OpenRouter',
+        domains: ['openrouter.ai'],
+        headers: {
+          authorization: '[REDACTED]',
+          'x-api-key': '[REDACTED]'
+        }
+      };
+      const headers = {
+        authorization: 'Bearer sk-or-secret',
+        'x-api-key': 'sk-or-key',
+        'content-type': 'application/json'
+      };
+      const sanitized = service.sanitizeHeaders(headers, pattern);
+      expect(sanitized['authorization']).toBe('[REDACTED]');
+      expect(sanitized['x-api-key']).toBe('[REDACTED]');
+      expect(sanitized['content-type']).toBe('application/json');
+    });
+  });
+
   describe('URL Sanitization', () => {
     beforeEach(() => {
       mockFs.existsSync.mockReturnValue(true);


### PR DESCRIPTION
## What's New

- **OpenRouter support**: `openrouter.ai` is now a built-in provider in `api-patterns.json`. Calls routed through OpenRouter are automatically detected and logged without any configuration.

## What Changed

- Added OpenRouter pattern matching for `/api/v1/chat/completions`, `/api/v1/completions`, and `/api/v1/embeddings` paths.
- `authorization` and `x-api-key` headers are redacted for OpenRouter requests.
- Added pattern-matching tests covering domain detection and header sanitization.

## Breaking Changes

None.