### PR TITLE
chore: finalize 0.8.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.0] - 2026-06-23
+## [0.8.0] - 2026-06-24
 
 ### ✨ New Features
 - **OpenRouter support** — `openrouter.ai` is now a built-in monitored provider. Covers `/api/v1/chat/completions`, `/api/v1/completions`, and `/api/v1/embeddings`. Redacts `authorization` and `x-api-key` headers. Works in both Node.js (file-loaded patterns) and Edge runtimes (Cloudflare Workers, Vercel Edge).
+- **Non-inference Anthropic GET filter** — Two noisy Anthropic operational endpoints are now silently dropped before reaching Coolhand's ingestion: `GET /api/directory/servers` (MCP server directory listing from claude.ai browser sessions) and `GET /v1/environments/:id/work/poll` (managed-agents environment work polling). Applied at all six interception sites (https.request/get, http.request/get, fetch). POST requests and all other Anthropic paths are unaffected.
+
+### 🔒 Security
+- **esbuild bumped to ≥0.28.1** — Adds `npm overrides` to resolve GHSA-g7r4-m6w7-qqqr (path traversal via esbuild dev server on Windows). Not exploitable in this project's usage but addressed proactively.
+
+### 🐛 Bug Fixes
+- **Node 22 test flakiness** — Replaced a hardcoded 50 ms timer in the gzip decompression test suite with a deterministic mock hook, fixing intermittent CI failures on Node 22 where libuv schedules zlib callbacks differently.
+
+### 📖 Documentation
+- Added `CLAUDE.md` with setup, CI gate, scripts reference, README/docs philosophy, cross-SDK alignment, and SEO/AEO guidance.
+- Added "About Coolhand Labs" section to README.
 
 ## [0.7.0] - 2026-06-08
 


### PR DESCRIPTION
## What's new in 0.8.0

Adds our remaining changes to the [0.8.0] CHANGELOG entry alongside the OpenRouter support already merged to main.

- **Non-inference Anthropic GET filter** — `GET /api/directory/servers` and `GET /v1/environments/:id/work/poll` are now silently dropped before ingestion. Applied at all six interception sites; POST requests and all other Anthropic paths unaffected.
- **esbuild bumped to ≥0.28.1** — resolves GHSA-g7r4-m6w7-qqqr.
- **Node 22 CI fix** — replaced flaky 50 ms timer in gzip decompression tests with a deterministic mock hook.
- **Docs** — `CLAUDE.md` and "About Coolhand Labs" README section.

## Breaking changes

None.