### PR TITLE
Filter Claude Code event_logging telemetry from proxy capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ New Features
 - **OpenRouter support** — `openrouter.ai` is now a built-in monitored provider. Covers `/api/v1/chat/completions`, `/api/v1/completions`, and `/api/v1/embeddings`. Redacts `authorization` and `x-api-key` headers. Works in both Node.js (file-loaded patterns) and Edge runtimes (Cloudflare Workers, Vercel Edge).
-- **Non-inference Anthropic GET filter** — Two noisy Anthropic operational endpoints are now silently dropped before reaching Coolhand's ingestion: `GET /api/directory/servers` (MCP server directory listing from claude.ai browser sessions) and `GET /v1/environments/:id/work/poll` (managed-agents environment work polling). Applied at all six interception sites (https.request/get, http.request/get, fetch). POST requests and all other Anthropic paths are unaffected.
+- **Non-inference Anthropic request filter** — Noisy Anthropic operational endpoints are silently dropped before reaching Coolhand's ingestion. Applied at all six interception sites (https.request/get, http.request/get, fetch):
+  - `GET /api/directory/servers` — MCP server directory listing from claude.ai browser sessions
+  - `GET /v1/environments/:id/work/poll` — managed-agents environment work polling
+  - `POST /api/event_logging/…` (any sub-path) — Claude Code internal telemetry batches; dropped regardless of HTTP method
 
 ### 🔒 Security
 - **esbuild bumped to ≥0.28.1** — Adds `npm overrides` to resolve GHSA-g7r4-m6w7-qqqr (path traversal via esbuild dev server on Windows). Not exploitable in this project's usage but addressed proactively.

--- a/src/non-inference-filter.ts
+++ b/src/non-inference-filter.ts
@@ -3,11 +3,16 @@ export const IGNORED_GET_PATH_PATTERNS: readonly RegExp[] = Object.freeze([
   /^\/v1\/environments\/[^/]+\/work\/poll(\?.*)?$/  // managed-agents environment polling
 ]);
 
+export const IGNORED_ANY_METHOD_PATH_PATTERNS: readonly RegExp[] = Object.freeze([
+  /^\/api\/event_logging\//  // Claude Code telemetry batches
+]);
+
 export function isNonInferenceURL(url: string, method: string): boolean {
-  if (method.toUpperCase() !== 'GET') { return false; }
   try {
     const u = new URL(url);
     if (u.hostname !== 'api.anthropic.com') { return false; }
+    if (IGNORED_ANY_METHOD_PATH_PATTERNS.some(p => p.test(u.pathname))) { return true; }
+    if (method.toUpperCase() !== 'GET') { return false; }
     return IGNORED_GET_PATH_PATTERNS.some(p => p.test(u.pathname + u.search));
   } catch {
     return false;

--- a/test/non-inference-filter.test.ts
+++ b/test/non-inference-filter.test.ts
@@ -1,4 +1,4 @@
-import { IGNORED_GET_PATH_PATTERNS, isNonInferenceURL } from '../src/non-inference-filter';
+import { IGNORED_GET_PATH_PATTERNS, IGNORED_ANY_METHOD_PATH_PATTERNS, isNonInferenceURL } from '../src/non-inference-filter';
 
 describe('IGNORED_GET_PATH_PATTERNS', () => {
   it('is frozen', () => {
@@ -38,7 +38,47 @@ describe('IGNORED_GET_PATH_PATTERNS', () => {
   });
 });
 
+describe('IGNORED_ANY_METHOD_PATH_PATTERNS', () => {
+  it('is frozen', () => {
+    expect(Object.isFrozen(IGNORED_ANY_METHOD_PATH_PATTERNS)).toBe(true);
+  });
+
+  it('contains exactly one pattern', () => {
+    expect(IGNORED_ANY_METHOD_PATH_PATTERNS).toHaveLength(1);
+  });
+
+  it('matches /api/event_logging/v2/batch', () => {
+    expect(IGNORED_ANY_METHOD_PATH_PATTERNS[0].test('/api/event_logging/v2/batch')).toBe(true);
+  });
+
+  it('matches any path under /api/event_logging/', () => {
+    expect(IGNORED_ANY_METHOD_PATH_PATTERNS[0].test('/api/event_logging/v3/other')).toBe(true);
+  });
+
+  it('does not match /api/event_logging (missing trailing slash)', () => {
+    expect(IGNORED_ANY_METHOD_PATH_PATTERNS[0].test('/api/event_logging')).toBe(false);
+  });
+});
+
 describe('isNonInferenceURL', () => {
+  describe('drops event_logging paths regardless of method', () => {
+    it('drops POST to /api/event_logging/v2/batch', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com/api/event_logging/v2/batch', 'POST')).toBe(true);
+    });
+
+    it('drops GET to /api/event_logging/v2/batch', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com/api/event_logging/v2/batch', 'GET')).toBe(true);
+    });
+
+    it('does not drop POST to a different host with event_logging path', () => {
+      expect(isNonInferenceURL('https://api.openai.com/api/event_logging/v2/batch', 'POST')).toBe(false);
+    });
+
+    it('does not drop POST to a different Anthropic path', () => {
+      expect(isNonInferenceURL('https://api.anthropic.com/v1/messages', 'POST')).toBe(false);
+    });
+  });
+
   describe('drops ignored Anthropic GET paths', () => {
     it('drops GET /api/directory/servers', () => {
       expect(isNonInferenceURL('https://api.anthropic.com/api/directory/servers', 'GET')).toBe(true);


### PR DESCRIPTION
## What's new

- `IGNORED_ANY_METHOD_PATH_PATTERNS` — a new frozen constant in `non-inference-filter.ts` holding path-prefix patterns that are dropped regardless of HTTP method.
- `isNonInferenceURL()` now checks this list before the existing GET-only guard, so `POST /api/event_logging/v2/batch` (and any other path under `/api/event_logging/`) is silently dropped at all six interception sites before reaching Coolhand ingestion.

## What changed

- The 0.8.0 CHANGELOG entry for the non-inference filter is updated to reflect all three now-filtered endpoints and to remove the stale "POST requests are unaffected" claim.
- 9 new tests added to `test/non-inference-filter.test.ts` covering the new constant and `isNonInferenceURL()` behavior for event_logging paths.

## Breaking changes

None. Existing GET-filter behavior is unchanged.

Closes #81